### PR TITLE
adding simple binder link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,3 +54,7 @@ html_theme_options = {"github_url": "https://github.com/ExecutableBookProject/my
 html_static_path = ["_static"]
 jupyter_sphinx_require_url = ""
 copybutton_selector = "div:not(.output) > div.highlight pre"
+
+binderhub_url = "https://mybinder.org"
+path_to_docs = "docs"
+repository_url = "https://github.com/ExecutableBookProject/myst-nb"


### PR DESCRIPTION
This PR will add simple functionality for Binder links with notebooks. Currently, all it tries to do is update the page context so that a template would have access to the Binder link. I'm not sure what is the best way to expose this in a way that *doesn't* use themes. I also wonder if `jupyter-sphinx` is also generating these links already with its thebelab support somehow, and if we could try piggy-backing on that? (@akhmerov do you have any thoughts on that?)