### PR TITLE
updating inline glue css

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -110,8 +110,9 @@ div.cell_output table {
 
 
 /* Inline text from `paste` operation */
-
-span.pasted-text {
+span.pasted-inline code, span.pasted-text {
+  background: #e9ecef;
+  padding: 0 .2em;
   font-weight: bold;
 }
 


### PR DESCRIPTION
I was reading [this fivethirtyeight article](https://fivethirtyeight.com/features/why-its-so-freaking-hard-to-make-a-good-covid-19-model/) and thought that they had an interesting approach to using "variables in prose". They set all variables to be mono fonts, and added a colored background to them:

![image](https://user-images.githubusercontent.com/1839645/78414291-5355ca00-75d0-11ea-9a05-7329d08a53e3.png)

This PR takes a step in that direction, adding a slight grey background behind inserted variable values, so that it is more obvious where we have "pasted" variables vs. regular text.

Another possibility would be to make the `paste:text` output an inline node instead of a text node, so it's mono-fonted as well.

An example of how it looks now:

![image](https://user-images.githubusercontent.com/1839645/78414854-0fb08f80-75d3-11ea-898c-1e7ea4899736.png)

from: https://343-241268229-gh.circle-artifacts.com/0/html/use/glue.html

What do folks think?