### PR TITLE
css to align and float figure directives

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -117,3 +117,36 @@ span.pasted-text {
 span.pasted-inline img {
   max-height: 2em;
 }
+
+/* Align figures */
+
+div.figure.align-right {
+  display: flex;
+  justify-content: flex-end;
+}
+
+div.figure.align-center {
+  display: flex;
+  justify-content: center;
+}
+
+/* Float figures */
+
+div.figure.float-left {
+  clear: left;
+  float: left;
+  margin-left: 1em;
+  margin-right: 2em;
+}
+
+div.figure.float-right {
+  clear: right;
+  float: right;
+  margin-left: 2em;
+  margin-right: 1em;
+}
+
+.highlight {
+  background: none;
+}
+

--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -149,4 +149,3 @@ div.figure.float-right {
 .highlight {
   background: none;
 }
-


### PR DESCRIPTION
I've added some basic css to align figures using `figclass` option.

Here's a quick screenshot of the documentation I'd like to add to the `cli`:
<img width="609" alt="Screen Shot 2020-04-08 at 3 20 55 PM" src="https://user-images.githubusercontent.com/33075058/78747349-8c18e900-79ac-11ea-9b40-c7ebca9fc8e8.png">


Would love to hear what people think about this @chrisjsewell @choldgraf 