### PR TITLE
Added a simple {tableofcontents} directive

### DIFF
--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -19,6 +19,7 @@ from .parser import (
     CellOutputNode,
     CellOutputBundleNode,
 )
+from .directives import toc
 from .transform import CellOutputsToNodes
 from .nb_glue import glue  # noqa: F401
 from .nb_glue.domain import NbGlueDomain
@@ -120,6 +121,15 @@ def setup(app):
         man=(skip, None),
     )
 
+    app.add_node(
+        toc.TableOfContentsNode,
+        override=True,
+        html=(toc.visit_TableOfContentsNode, toc.depart_TableOfContentsNode),
+        latex=(toc.visit_TableOfContentsNode, toc.depart_TableOfContentsNode),
+        textinfo=(toc.visit_TableOfContentsNode, toc.depart_TableOfContentsNode),
+        text=(toc.visit_TableOfContentsNode, toc.depart_TableOfContentsNode),
+        man=(toc.visit_TableOfContentsNode, toc.depart_TableOfContentsNode),
+    )
     # Add configuration for the cache
     app.add_config_value("jupyter_cache", "", "env")
     app.add_config_value("execution_excludepatterns", [], "env")
@@ -139,6 +149,7 @@ def setup(app):
     app.add_js_file("mystnb.js")
     app.setup_extension("jupyter_sphinx")
     app.add_domain(NbGlueDomain)
+    app.add_directive("tableofcontents", toc.TableofContents)
 
     # TODO need to deal with key clashes in NbGlueDomain.merge_domaindata
     # before this is parallel_read_safe

--- a/myst_nb/directives/toc.py
+++ b/myst_nb/directives/toc.py
@@ -1,0 +1,51 @@
+from typing import List
+
+from docutils import nodes
+from docutils.nodes import Node
+
+from sphinx.util.docutils import SphinxDirective
+from sphinx.util import logging
+from sphinx import addnodes
+
+logger = logging.getLogger(__name__)
+
+
+class TableOfContentsNode(nodes.General, nodes.Element):
+    pass
+
+
+def visit_TableOfContentsNode(self, node):
+    pass
+
+
+def depart_TableOfContentsNode(self, node):
+    pass
+
+
+class TableofContents(SphinxDirective):
+    # this enables content in the directive
+    has_content = True
+    option_spec = {"maxdepth": int}
+
+    def run(self) -> List[Node]:
+        subnode = addnodes.toctree().deepcopy()
+        subnode["glob"] = False
+        subnode["maxdepth"] = self.options.get("maxdepth", 1)
+        ret = []  # type: List[Node]
+        subnode["entries"] = []
+        subnode["includefiles"] = []
+        self.set_source_info(subnode)
+        wrappernode = nodes.compound(classes=["toctree-wrapper"])
+        wrappernode.append(subnode)
+        self.add_name(wrappernode)
+        all_docnames = self.env.found_docs.copy()
+        all_docnames.remove(self.env.docname)  # remove current document
+
+        for docname in all_docnames:
+            if "index" in docname:
+                continue
+            subnode["entries"].append((None, docname))
+            subnode["includefiles"].append(docname)
+
+        ret.append(wrappernode)
+        return ret

--- a/myst_nb/directives/toc.py
+++ b/myst_nb/directives/toc.py
@@ -3,9 +3,10 @@ from typing import List
 from docutils import nodes
 from docutils.nodes import Node
 
-from sphinx.util.docutils import SphinxDirective
-from sphinx.util import logging
 from sphinx import addnodes
+from sphinx.util import logging
+from sphinx.util.nodes import clean_astext
+from sphinx.util.docutils import SphinxDirective
 
 logger = logging.getLogger(__name__)
 
@@ -28,24 +29,85 @@ class TableofContents(SphinxDirective):
     option_spec = {"maxdepth": int}
 
     def run(self) -> List[Node]:
-        subnode = addnodes.toctree().deepcopy()
-        subnode["glob"] = False
-        subnode["maxdepth"] = self.options.get("maxdepth", 1)
         ret = []  # type: List[Node]
-        subnode["entries"] = []
-        subnode["includefiles"] = []
-        self.set_source_info(subnode)
         wrappernode = nodes.compound(classes=["toctree-wrapper"])
+        subnode = nodes.bullet_list()
         wrappernode.append(subnode)
         self.add_name(wrappernode)
-        all_docnames = self.env.found_docs.copy()
-        all_docnames.remove(self.env.docname)  # remove current document
+        depth = 0
+        if hasattr(self.config, "globaltoc"):
+            # case where _toc.yml is present
+            self._has_toc_yaml(subnode, self.config.globaltoc, depth)
+        else:
+            # case where _toc.yml is not present (Not sure if necessary)
+            all_docnames = self.env.found_docs.copy()
+            all_docnames.remove(self.env.docname)  # remove current document
 
-        for docname in all_docnames:
-            if "index" in docname:
-                continue
-            subnode["entries"].append((None, docname))
-            subnode["includefiles"].append(docname)
+            for docname in all_docnames:
+                if "index" in docname:
+                    continue
+                subnode["entries"].append((None, docname))
+                subnode["includefiles"].append(docname)
 
         ret.append(wrappernode)
         return ret
+
+    def _has_toc_yaml(self, subnode, tocdict, depth):
+        depth += 1
+        for key, val in tocdict.items():
+            if key == "header":
+                self._handle_toc_header(subnode, val, depth)
+            if key == "file":
+                if val not in self.env.titles:
+                    continue
+                title = clean_astext(self.env.titles[val])
+                val = "/" + val + ".html"
+                reference = nodes.reference(
+                    "",
+                    "",
+                    internal=False,
+                    refuri=val,
+                    anchorname="",
+                    *[nodes.Text(title)]
+                )
+                para = addnodes.compact_paragraph("", "", reference)
+                item = nodes.list_item("", para)
+                item["classes"].append("toctree-l%d" % (depth))
+                subnode.append(item)
+            if key == "sections":
+                sectionlist = nodes.bullet_list().deepcopy()
+                sectionheader = None
+                headerlist = None
+                for item in val:
+                    if "header" in item:
+                        if headerlist:
+                            sectionlist.append(sectionheader)
+                            sectionlist.append(headerlist)
+                        headerlist = nodes.bullet_list().deepcopy()
+                        sectionheader = self._handle_toc_header(
+                            sectionlist, item["header"], depth
+                        )
+                    else:
+                        if headerlist:
+                            self._has_toc_yaml(headerlist, item, depth)
+                        else:
+                            self._has_toc_yaml(sectionlist, item, depth)
+                if headerlist:
+                    sectionlist.append(sectionheader)
+                    sectionlist.append(headerlist)
+                subnode.append(sectionlist)
+
+    def _handle_toc_header(self, subnode, val, depth):
+        if val in self.env.titles:
+            title = clean_astext(self.env.titles[val])
+            val = "/" + val + ".html"
+            reference = nodes.reference(
+                "", "", internal=False, refuri=val, anchorname="", *[nodes.Text(title)]
+            )
+            para = addnodes.compact_paragraph("", "", reference)
+        else:
+            para = addnodes.compact_paragraph("", "", nodes.Text(val))
+        para["classes"].append("toctree-l%d" % (depth))
+        item = nodes.list_item("", para)
+        item["classes"].append("toctree-l%d" % (depth))
+        return item

--- a/myst_nb/directives/toc.py
+++ b/myst_nb/directives/toc.py
@@ -40,14 +40,8 @@ class TableofContents(SphinxDirective):
             self._has_toc_yaml(subnode, self.config.globaltoc, depth)
         else:
             # case where _toc.yml is not present (Not sure if necessary)
-            all_docnames = self.env.found_docs.copy()
-            all_docnames.remove(self.env.docname)  # remove current document
-
-            for docname in all_docnames:
-                if "index" in docname:
-                    continue
-                subnode["entries"].append((None, docname))
-                subnode["includefiles"].append(docname)
+            # TODO: Implement after consulting with team
+            pass
 
         ret.append(wrappernode)
         return ret


### PR DESCRIPTION
**NOTE** : This branch is work in progress. The implementations can change drastically.

@choldgraf @jstac @mmcky @chrisjsewell @najuzilu 

@choldgraf I know you mentioned here https://github.com/executablebooks/jupyter-book/issues/503, that we don't necessarily need a `{toctree}` node, but I wanted to try out a basic implementation of it, just for the ease with which it creates titles and links under the hood.

Do you think it can create complications in the future?

It has neat features though , which we can leverage.  For example :- 

1. 

Code :- 

```
```{tableofcontents}
```

Result :- 

![image](https://user-images.githubusercontent.com/6542997/80852860-572c4900-8c6f-11ea-9d93-0455073b99d6.png)


2. 

Code :- 

```
```{tableofcontents}
:maxdepth: 2
```

Result :- 

![image](https://user-images.githubusercontent.com/6542997/80852843-3532c680-8c6f-11ea-84a3-6b9249a7d666.png)

