### PR TITLE
executing notebooks w/ nbclient in their directory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,10 @@ html_logo = "_static/logo.png"
 html_theme_options = {
     "github_url": "https://github.com/executablebooks/myst-nb",
     "repository_url": "https://github.com/executablebooks/myst-nb",
+    "repository_branch": "master",
     "expand_sections": ["use/index"],
+    "use_edit_page_button": True,
+    "path_to_docs": "docs/",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,9 @@ examples/index.md
 Finally, here is documentation on contributing to the development of MySt-NB
 
 ```{toctree}
+:titlesonly:
 develop/index.md
+GitHub Repo <https://github.com/executablebooks/myst-nb>
 ```
 
 [github-ci]: https://github.com/executablebooks/MyST-NB/workflows/continuous-integration/badge.svg?branch=master

--- a/myst_nb/cache.py
+++ b/myst_nb/cache.py
@@ -144,7 +144,7 @@ def add_notebook_outputs(env, ntbk, file_path=None):
             )
             if not has_outputs:
                 LOGGER.info("Executing: {}".format(env.docname))
-                ntbk = execute(ntbk)
+                ntbk = execute(ntbk, cwd=Path(file_path).parent)
             else:
                 LOGGER.info(
                     "Did not execute {}. "

--- a/tests/notebooks/basic_relative.ipynb
+++ b/tests/notebooks/basic_relative.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# a title\n",
+    "\n",
+    "some text\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test reading a relative file to make sure relative paths work\n",
+    "with open(\"./conf.py\") as ff:\n",
+    "    ff.read()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  },
+  "test_name": "notebook1",
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -134,3 +134,20 @@ def test_jupyter_cache_path(sphinx_run, file_regression, check_nbs):
     assert sphinx_run.warnings() == ""
     file_regression.check(sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb")
     file_regression.check(sphinx_run.get_doctree().pformat(), extension=".xml")
+
+
+# Testing relative paths within the notebook
+@pytest.mark.sphinx_params(
+    "basic_relative.ipynb", conf={"jupyter_execute_notebooks": "cache"}
+)
+def test_relative_path_cache(sphinx_run, file_regression, check_nbs):
+    sphinx_run.build()
+    assert "Executing" in sphinx_run.status(), sphinx_run.status()
+
+
+@pytest.mark.sphinx_params(
+    "basic_relative.ipynb", conf={"jupyter_execute_notebooks": "force"}
+)
+def test_relative_path_force(sphinx_run, file_regression, check_nbs):
+    sphinx_run.build()
+    assert "Executing" in sphinx_run.status(), sphinx_run.status()


### PR DESCRIPTION
This adds the `cwd` command to our call to `nbclient.execute`, and also updates a test to use a relative file path in the code to make sure it works

fixes #180 

