### PR TITLE
fixing ipywidgets

### DIFF
--- a/docs/examples/interactive.md
+++ b/docs/examples/interactive.md
@@ -104,6 +104,13 @@ You may also run code for Jupyter Widgets in your document, and the interactive 
 outputs will embed themselves in your side. See [the ipywidgets documentation](https://ipywidgets.readthedocs.io/en/latest/user_install.html)
 for how to get set up in your own environment.
 
+```{admonition} Widgets often need a kernel
+Note that `ipywidgets` tend to behave differently from other interactive viz libraries. They
+interact both with Javascript, and with Python. Some functionality in `ipywidgets` may not
+work in default Jupyter Book pages (because no Python kernel is running). You may be able to
+get around this with [tools for remote kernels, like thebelab](https://thebelab.readthedocs.org).
+```
+
 Here are some simple widget elements rendered below.
 
 ```{code-cell} ipython3
@@ -131,6 +138,5 @@ tab.titles = [str(i) for i in range(len(children))]
 tab
 ```
 
-```{code-cell} ipython3
-
-```
+You can find [a list of possible Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html)
+in the jupyter-widgets documentation.

--- a/docs/examples/interactive.md
+++ b/docs/examples/interactive.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: '0.8'
-    jupytext_version: '1.4.1'
+    jupytext_version: 1.4.2
 kernelspec:
   display_name: Python 3
   language: python
@@ -62,7 +62,6 @@ the renderer option to get the output you want.
 ```
 
 Below is some example output.
-
 
 ```{code-cell} ipython3
 import plotly.io as pio
@@ -134,7 +133,8 @@ tab_contents = ['P0', 'P1', 'P2', 'P3', 'P4']
 children = [widgets.Text(description=name) for name in tab_contents]
 tab = widgets.Tab()
 tab.children = children
-tab.titles = [str(i) for i in range(len(children))]
+for ii in range(len(children)):
+    tab.set_title(ii, f"tab_{ii}")
 tab
 ```
 

--- a/myst_nb/parser.py
+++ b/myst_nb/parser.py
@@ -170,9 +170,9 @@ def nb_to_tokens(ntbk: nbf.NotebookNode) -> Tuple[MarkdownIt, AttrDict, List[Tok
 
     # If there are widgets, this will embed the state of all widgets in a script
     if contains_widgets(ntbk):
-        state.tokens = [
+        state.tokens.append(
             Token("jupyter_widget_state", "", 0, meta={"state": get_widgets(ntbk)})
-        ] + state.tokens
+        )
 
     return md, env, state.tokens
 

--- a/tests/notebooks/complex_outputs_unrun.ipynb
+++ b/tests/notebooks/complex_outputs_unrun.ipynb
@@ -320,6 +320,25 @@
     "f = y(n)-2*y(n-1/sym.pi)-5*y(n-2)\n",
     "sym.rsolve(f,y(n),[1,4])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive outputs\n",
+    "\n",
+    "## ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Layout(model_id=\"1337h4x0R\")"
+   ]
   }
  ],
  "metadata": {
@@ -381,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -456,5 +475,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -102,6 +102,11 @@ def test_complex_outputs_unrun(sphinx_run, file_regression, check_nbs):
     file_regression.check(sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb")
     file_regression.check(sphinx_run.get_doctree().pformat(), extension=".xml")
 
+    # Widget view and widget state should make it into the HTML
+    html = sphinx_run.get_html()
+    assert '<script type="application/vnd.jupyter.widget-view+json">' in html
+    assert '<script type="application/vnd.jupyter.widget-state+json">' in html
+
 
 @pytest.mark.sphinx_params(
     "complex_outputs_unrun.ipynb", conf={"jupyter_execute_notebooks": "auto"}
@@ -112,6 +117,11 @@ def test_complex_outputs_unrun_nbclient(sphinx_run, file_regression, check_nbs):
     assert sphinx_run.warnings() == ""
     file_regression.check(sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb")
     file_regression.check(sphinx_run.get_doctree().pformat(), extension=".xml")
+
+    # Widget view and widget state should make it into the HTML
+    html = sphinx_run.get_html()
+    assert '<script type="application/vnd.jupyter.widget-view+json">' in html
+    assert '<script type="application/vnd.jupyter.widget-state+json">' in html
 
 
 @pytest.mark.sphinx_params(

--- a/tests/test_execute/test_complex_outputs_unrun.ipynb
+++ b/tests/test_execute/test_complex_outputs_unrun.ipynb
@@ -417,7 +417,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa8AAAA/CAYAAABXekf2AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAToklEQVR4Ae2d7bXdtBKGD1kUEHIruKED4FaQ0AFwKwA6gJV//MuCDsKtIEAHQAUBOoASQjrIfR8fzcbbxx+SJcuyz2gtb39Jo9E7Go1GkrXfefv27Y2H8gh88803L0T1T52/K0/dKY4hIKwf6/nPOj7U9ZuxOP7MEYhBwPU3BqWycVL190HZ7J0aCEgIX+j0kc5uuCpWCeH9l7Kj0/BjxWw9q5Mh4Pq7j0BT9deNV2E5SQAfiOS3Oj4tTNrJRSAg/LsOg87IwIMjkISA628SXMUjp+ivG6+C8Av4hyL3q46vdY0X4GEfBOg4fCEZfLJP9p7rERFw/W1GalH6+47PeZUTmCo/Q1YMF35Yjuo5KQkjPNTfY0un+O/ExiWe4mO4/qfj37r2+S9A8TCLgOqJ6+8sQv+8FFa76++7/7DjVzkIBGEy1+WGKw5IhvVYWPFHXPS0WKL7kw7y4PgyLbXHvm8IuP4mS3x3/fVhw2SZTSagl0+DuUljPJnrAV+EhuKmAlZfCx6GDx8fECZnuS4Crr+ReLeiv268IgU2F03CZIgKN5rG0sMyAs8UhZ5bF0wZ7J6znj3UkWV0lP4nkaIzwXCQB0dgFAHVE9ffUWQmHzahvz5sOCmfpBc0xL9ICZIWaSg+Bo9l3c19lyTeMBxmjD/S9Wvu9TzLswx0H+v8i+hZ+FX3LHYx2lwTJodgFf8rvX9f56UhweeK96PifaDD6EPbgyNgCLj+GhILZ+kQ7UIT+uvGa0FYS69pFBGmDmvoZ5MoPg0zQxQYA4xClneh9MVDqKDf6nxZ7q9rFPx3nT/W0Tc8qfmD0xArsOAASzoAeEzPlc/cQguMFvFmg2gwlAsd4i8Zulla/vJ8CKhuuP6mibUZ/XXjlSa4sdi40Dc0kmMvh89CQ9oZBV3jPaA8rQUM1ed9psQrXhcLUvAU3+u/i71Wegw3qzGHRuQPPbsYyhh6iv9+TLwQ5wed4X2YbwIJj3pSBFx/IwXbmv4+iOT7NNEkADwKJvG/4toKpmsa1qQQ0jBe/n1SwvYjPxWLf49ggseVMxcF3s93KH6344bKgwHzcGAEJEPX32X53Qv9nTVeqigvWlN48UPjyfDVGmPzp+T+Umm/18FODIzd4v0Q1jRsn90mPd2CAIzUX8KG4baxsAZ70jwVzSgPdSzTtc+UJ+WhLIfyvMR3c/q3VgaWTmVy/TUwtjvfC/2dHDZEcYTtI52b8irEzxsdDGkxyf+E+5g6oHiUh+Gp/qT9z3r2ZXjWfx5Dkjg2/LcmbWwe1eMJj6khvG6Ic4BhLH8Mz1w83WEi0aTzYEaRIUEa7itcdc974vE+ddPjbuhQNOiwJC2sUV7Vg3hsUv9ygVC5XH9zQVxIL4zvhf6Oel4qPA0EcxNTICzAt+1r8UWjhnKnbMCKl/RywBmN2GMdaxch4J7Tyzl9EOaTE9t694kOsJgLxJnqCGGUftD77zh0jZHDux7SfBbeI3eMYUqgo0IY0rx92tCvyti0/uVCpfK5/uaCmJhemJ9Of+8Yr1BIGo8nifhUjS4+u4ZQZxv2W8qfBvKqJ6/71zp4njwPo3ytERzSFLlTBgyGDbdeChjwZ/XknFeFjOhsjAbRoPPwxl7qmk4FnYJLGj2jk/EqxKFTleo9mZw+DjSaPKmcNDLN618ueCqn628uiGnpT6e/d4yX8KAhopG6NCZpGFWNzRwGE7g0bEuBxusST2kwWv8lEWUN99zGBvNKrUcfm+5w8YQNRoTv2K7mjHQPnjRCHHxH1Q0r6noYGJrFo0oJnVcc8iDda13bfBmeycsUYkoLPeq0dTpSkteMeyT9y8XF9TcXwYj0qvun1N93+2VXIe1L86Jel+jSqGEoYr2kG6VZ3IhVcVhUQMOJcJZ61BgblnvT4OJxMffBPRPI8EXjZo2jLhcD32gRfrs9nfNX2GAobnS+MlzhWef96N1z3YPhMx1m1IlCOtIjn9Gg9xh/5lanPkimkwGdrjOlM3WU0PXcby+jf5HVU9FA5h296JQVIoayoStF9S+XdfHl+psL4k7pJbvT6u+V8RK+DFcw71BasaGLoRh+nFpCpNBm8n52Il7vaWjHGuA7zyKZQqHnVuRFkmk3mjDDUFztYgHOcBzw7JjXNZ4rxuQLnYdyQOZThon0dALoTAzDIx6Ing332XsMpH14bM9izxhKPC+OlI5KLP3ceFvpXwm+XH9zUaycXrpzav19YHiqoDTGNEz0oouFQPdG52EjVCQP0cUoMT+y1ggl86E8uwZcCTvPI5nAARKojNSH/+g87HCgEGPGhoaXcImvtMRdMjQMUbN6cBgwMFeLYRQPLwy+XhJZ95YntzHB5LXkpcfQKhpHZdlE/3KZDHyBtetvLpgV0we5nVp/L8ZLuNKjZV6jtNcF3dRGJlXMTEZ27nFqwpXxaWgI1hje3p3kV3UA4wymDK+xZN0OnjF/daeO6Jl1IvC+MDIEZL/UGepod7HDj9Lb8PLVEKRe46Xd6D0GER75bi8lmLys85GSduu4W+lfLt+uv7kIVk4fdOP0+tsfNqSXXNR7CSAyjDTsQd/ZJFVxaPCY+7AGJkXk0KehZTl2jeEga/xSG8+uTOKxq1i66RpjnVkWTs/2lc6pCxs6moV/4I8yjnUI5nrgdFLwmDBgyPE3ne8YOj2/BOLpYNHNi/Dwkc54dnf+RFJx6FxxYNxsqDIkizpZ3TL5RSWqFKm4/uXyLZzByfV3AKRwcf0NmAiL3fS3M15iwDyJKyMzkNmaW4aQLsNIPQJJu4iLPxqrq7mXHq2bACANE8NBNYyXDXNZY9hnZ/Fa/A49isU0NSOIv7k5qklWlA7DgnGjtw42UeVUGuJGdZwUd/WQn9Ji8JRVZ5g5NxHE01b6l1s+198RBCWvqHo9krTKI/F3L/T3QUDThmNWNcZjEhGAeFJ86DxmEOlZkxdKSzwMztzfgtCwzfbg9Z58zJPR5abBeu7F8NqU27rEGSZEpvTIWsSnq0ehftZFZjq34vo3nVXcG9ffOJxOGOsw+mvDhvRm54aD1siIISSAGAtJu4hLkczTGaNlzxjCGxvmsvclzwxtEZYM6m2se/QrWTEfhdEa87hbQMI6TcgwS34qJ0OkDKutWbbfx2IL/evTX3Pt+rsGtYw0BevTai7Ew2H01zwvlLBYL1kA0PN+ChCrUUxP2PGvPG0IJp1CfArzvPAgPQwQkAwY4i1Wnwbkc29NZibDHHrUc47cUFT/cpmR7Fx/c0Fcl75UfVqXe0h1FP014wVoJRubGiuUhgIy/ks0SkPaw/uuwZKQ3wxf+H3zCJjMOhk2wi28WP1tgSXX3xak4DyMIXDRXxs2JFLUyjk12KyKYuJ7bC7LMmPV3+xQn94zxGcNCHFZMn0ZutQ174jDu5gdxE35bUhPyTw4AodBIEr/cksjvXL9zQXR0zeBwANVZvNUbDhlkjHFZdUfe69NfrcV4tiy5ylaGKalXcSfiRbLxlmWSk9wNijuxSLPRvSX9x0Bq+dNdHJUb6P1L1dwQTddf3OB9PR7InDRX4YNzfuZZSgoGRPTHFmbsIrW7C7iIa9XgSGWpZpXFR7Nnv41+zbzpXiLwiszG09+fxCoUp9cf28rlOvveRSLYUPrgZrnMlo6Cb0zIDqzghAPDG/o6nsHvWOYb8nrUpTRAH0WedATHe4gnrJyrUpjIB5n8RotYaGHwogy/qojpayfKt1lWLYQK0ckY3KLxk64UadZVDEMne7o/ZfDF7qPXVEbq39ZMhePrr/XQrJ6cP20wt3G9alCCXbNwuT2EONlbliUMgt429mAXRRYJtz3ijAysx/IKf7iLuJGU2fG5wm5S5Fvqez8q/K8jWVBcSd31dc7BDiLc2w+w3gpPA7T7nk/h1cuX6I9Zpxu9Jz6iQ7k7IoSpX/Ko4jMoaMDfXL9TawYwq2U/m5Wn1J4TCz+ptHF92R7N5Vxf8HGVJyx58x54WVhrDpBKHMUmW8EzDLqdjR8pKemsP0I1ovtewd4dzE0b5SvGd8qE999xmOvxWOygGJpl4p3BB5LlfUe03H9XSH8I+jGEXhcAf1oEua8zNjY8MVoxP5DAYS3xWpDem9mNDA0z/vxJq6jdhEPdD8QjZfQ0f3kIpGQj/Fv5QmPy57Eh9G3cpfNwKltjYDJzeS4dX5L9I0Pq79L8bPfqw67/qYNuWdj7gSKIXDRX4yXeUH2MDYXMyYYMLyu33oN+xyN2F3E8dBuRBPPi3mwJY/K+LfyzPHg7xyBVhCw+mr1txZfrr+1kPZ8NkGApfJvRJlj9rusYe5Kh+fFEB8eF4cpgy6ng9LR6+t2Edc1hoyl8OR9tYt4oG87iLOQY2ney3qulMWDIzCFgNUTMxpT8ao8V71epX+5zAX9cv3NBdLT10bgor8254VBwbtJDQwTYnySNmGV4pDf6KRlnwHFS9lB3Pj/rU9jo2sanIcb0T4NWcmv9F/flMCmRbmt1b9cPFx/cxE8cfrW9deMFw3+Z6lyUOEY0kPxUpayp2YTG5/VdxhRDMvWgV77Q+XFkZyf0mBoDTNbwMLfrNMTPlNI+uubygWn3uYGZJ8s/5FMV+nfCJ2kR6pvrr9t6W+p+pRUD2YiN62/Zrx+VwG6xRepjbHiJw03zgCV++qpCNRq/K2njAub1HgJLwwXw6aXb+R0zZArf0jJx9tz224p2qECRp7jAx1gxkbNz1XGJMyUpmQwDz2bh4KyWq1/ucCoDK6/CSAKr830t2B9SijRbNSm9deM1w8qwgsdGAAamEMFCf2hGO4qVSXGrddOnnYdmzWG6vN+ZPGP18WnBwzBvtd/d/Dr2A91axazGzMX3qly25LHQ+tfLjCuv7kIbpa+af19QLFVeeiF0uNPmWMiaSsBo0uo5bVYrx3jlRrg9e+gsP208M4w5BqafTp+PY8AHR2T33zMSm9PoH+5SLn+5iJ4f9Jf9LczXqHc9PqT570awaz7Mz81ArV607Zsf82QC0Zqbm4O4XjYAIFex4DhkNbCkfUvF0vX31wE70H6of6+2ytzN3ShCCxLr+XB9LLPusToXg3FZVFbTmxGMtlLEraXua5BNswL3ej9H4Pnh75VeRgONYOMsb/665vKhTN5tYjxkfUvV4yuv7kIbpS+Zf29eF5ikqGU73REfa+1EVbJZMX3VyTSueZcHavDCNYY3t6t/BXvGC5o2QrElZSaS4bRWvrrm5pMm7xe1cw0Ji/VgUPqX0zZ5uKo3K6/cwDt+65p/b0YLzBSRaLxZKPRzgvYF7fo3PlAuqbXBU40NHhfpXBiyIhts+g8nCaoPLN/fbNDQW0z4yZHFoTXEfUvV4yuv7kIbpS+df29Ml4BAxSIP6xrPghcem3MH9X0ugyXrgFU3tabt+dJZ6VnlSc7iSx+tJ1EuN3IGH06SFm4rSyebTnW4rChFekw+mcMrz2rDrj+rgVvv3TN6O8d46UK1W3DFCrWfhAt5BwaP3ptU3NICxSyX/NtDsFWSt3eJfyqDMwH3eh8OsOlMv2swzAaQ4UhidoBT9nmK2vnHZWfMDuE/kUVZiaSyknnxfV3BqM9Xx1Bf+8YrwDYE52/DBVsTwxH8xZfNHz8L9jnut6rMbKhJxuKGuV16qH4ZjPj93W+GC5d7+WRTLGZ8xwvZ8xAPYKoylrV+1F+NsS7h5eeimPT+pdamGF8ycL1dwhKe/fN6++o8VLleiMsWb76Y6horUHLHBG7VOzWEClvjCY4JXteSktD+h+dGSLqBwza6/6DA19H/fVNxfKZnF5WzHNVVqoXrevfqnL1Ern+9sBo9LJ5/R01XoApBaJxZkgO976ZIL7otWG4lnaZr8EzPOAtwVNUUFzwRHn5ILn7e5hw5hneLg3XGULsX9/UKiudsTfCt6rHt7Zw4rNJ/VtbHkuncrn+Ghhtn5vX3/53XnegDAp05/meD8QTjbsN2e3JCnmz2IJJZ+auYlcKYqQwYN18l879cIiGtc/w1DV1R0f31zchDsOFeJVXf30zlb7kc/FBg4nntZunvqY8YLgmXctpVCbX35YFFHij7uloWn/fefv27QGgbJdFCbhblKDzqrmvdkt2Hs4kGzoKdDQ+1PVpOgjnkdB+JXH93Q/72Jyn9Hdy2DCWsMfrGkX+t6qp4VWXyxUCLIqhJ+mG6woWvxECdGpcf9uuCqP668YrX2hs60O4rBq8vfXfFhAInQoWyBxq55gWsLsnPLj+NizoOf1145UpOIHLGD4LN8bmsDKpe/ICCHSdCsmphQU+BYrjJEoi4PpbEs1NaE3qrxuvMniz5J3Vg90+bWVIOpVcBCQPFmogk+EnCbmkPf25EHD9bVCeS/rrxquA0ELvDQVgxwAP7SDAUCFzXbErQdvh3DmphoDrbzWoUzOa1V83XqlwTsQPDeRrnd37msCo5mPJ4bHyYyjX5yJrAn/QvFx/2xJcjP668SorMxpKvo2g4fSwLwL02n6SLFr5JnBfNDz3GARcf2NQqhNnUX/deBUURGgoGaLiQ2QPOyEgOeBx8VFy1b/K2am4nm0hBFx/CwGZSSZWf/0j5Uygx5ILfDYNZld1n2sZA2jDZ8Icr5cPx5/o2r/r2hDrs5J2/d1Psin6657XNnJiT0j2KbSdzLfJxamOIYDX+7UbrjFo/FkkAq6/kUBtEC1af914bYC+Gk6+/WIjWPbz81AJAeHO0ngMl3/TVQnzM2bj+ruPVFP19/8PVQ3F1sRV/AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb0AAAAeCAYAAAC40cCwAAAABHNCSVQICAgIfAhkiAAACc1JREFUeJztnXusHUUdxz+9vdAKtVBfNOLjFos8JNDQlohiOVWkNharaDU+0DUaY2IhikYFi68YX9iAGqEEgqBSRRIgKZY/QDAtjaiEVklaFZEjITwCEtqirUpb//jN5p7u3cfM7G939t4zn+Tm3OzO/OZ3Zn7fc2bndSASiUQikQgA00M7kEMbPs1ooYxItzg0tAMldFGHWjT93qKWh5NCPY+UZBoBzvco7IDyX5blwHwPv2w5BzijQfvDwuE0GwfaLADe1kI5rvjqUIOmtQzN6jlqWY82YkETLz1/CzjRMc9C4JOuBTkyDfgxcGQDtk8Arm3A7rDRRhw0wVrglNBOZPDRoQZttWFTeo5a1mMo9PxGk8GVLwOv9MjnyiLgh8o2R4B7gLnKdoeRtuJAmyOALXRnONFXhxq02Ybaeo5a1mUo9LwJ6Sm5co1HHl/+AIwp2vso8AtFe8NMm3GgzVXAx0I7YfDVoQZtt6GmnqOWdZnyel4G/N7D+FHANzzy+fJZ9BpjGvBX4Gwle8NM23GgzWnAo8DMwH746lCDEG2opeeoZV2GQs83At/1MJ4Ab/DI58tiYDdwmIKtpcBeYFTB1rCT0G4cNME/gfcG9sFXhxoktN+GWnqOWtYlYYrreTqwE3i/h+ErKV8Nqs1M4Hlk9VceC4FfA3uAvwFLkDe+JSftj5DhlUh92o6DJrgT+GXA8uvoUIMQbVim56jlcEw5PWffzEnAbOCPjkYPAfYB+2u5VsyFyDLXDwxc24sMY+T1QhYDm4G7gZOBe4GvAV8CLslJfyawVdHfYSVEHDTB/UhMhMJXhxqEasMiPUcth2NK6jn7pXeceX3K0egZyGqpIvoU79d4wsL+IvN6X+b608Brc9KvBTYgY9EPAuuR3uEzwF2ZtIciiwX6JeW/B1ldthnYZfz+mYXfIGPi+0z+jwO3IL3VPUhv/h5kojVUb+rFin6FigM4uJ7rlvcP4GXGZgh8dahByDbM03NXtaypGy20fQoVC5pahoyes+PeR5vXXRYOD7IM+E5Fmp3A5TnXn7Ow/0Xg60jQD7KLcZ9T5gJvQsb2U/6LNHhez/DV5t7OkvLXIPs9nkMmRY+38DllpbG/HbgaeBzptT6CNMK5yAT+cmAV7WzcHGQVMoSh4VeoOIDxer5Zobw0FuYBT1r4pY2vDjUI2YZZPXdVyzejqxsttH0KFQuaWk7zQYGe1wD/Kck8Qv4E8VUVhfYp7335cgMThzKWIo06a+Dap4A/F9g4zaQ/r6ScpcCxyMqwHm69w9uRHuxbkBMisr2tuUhwHgDebWlTkzfj7lfX4gDG63lwT45vee9A3rfvCS2Jyd/zzF+lQw262IZZPXdVy9Px040NCf6x4+tT12JBU8uQ0XO2cvbnXEuZA2wEPpi5fgzwkKczNqSBf2nOvVHkMXiQI0369PoLkfH/fxfYT8/mK7oP0mt6EPde22wkEDcgE/EbmDg+/gSwzvzfc7SvwV24+dXFOBis52w8+JDGQqhtC2U61KCLbQgT9dxVLe/DXTdt4ONT12JBW8uQ0XP22323uXYYEwPndcij4Qrg+oHrK4BfWRQ8A/gQ8CrgX8CfkM23VW/sVPN6f8692cbnQbYhvbiLkJ7jpcjj/nykh5d9lN5jXmehzwpknuGWinT/M6/PN+BDHfL86mIclNWzT3lpLOwpSdMkZTrUoIttCBP1PBm1DN3Uc5FPXYsFbS1DhZ5XIt++Rcf3HIuMjx4ycG1dQdpB+uRPQP6d6lVyN5i0x+Xc28LBDZVyMbIIYK/JP8ekzVsYcIyxb3uobw/7IZGbkPHmsieGUeABY3OZpQ9tUOZX1+KgqJ59y/uwSbeoJE0ZCfWGN6t0qEHX2hDy9TyZtAz19ZxQL3byqPKpS7GgrWWo0PN8c3NhiYG/IPNTICfp25wN+BXkkfUopPd6ElKp+5GebNmhoDuQ3t+0nHsPA5+3KL+MUaQXtMYyfQ87ocxE/L6pIt33jD2bXlWbVPnVlTgoq2ff8s5H3vucqjdUQEK9Dy4bHWrQlTZMqavn0FqG+npO0P/Ss/GpC7HQhJbBQs+PI8tei1gLXGb+X0nx5nAb0sYoGjI4HHl03ZxzLx3vP71G+Slbgess0/awE8o5VO9BucCk2QG8yLL8PsVLd/P+bCfpXf3qShzY1LNred9HPoBt6OPWHtdZ2i3ToWuZRTHQlTYEPT2H0jK467lPM7Hj41MXYqEJLUNGz3krdm5lfLw1j9uQVT2fQYLmIgcHs6xDztxbUnD/FGRCP28OYAHwGPC7GuWn3A2cpWBnkHOR5dVFvavVSGNsR3pYz1jafQgZ6rHlMYe0Ln51JQ6q6tmnvFORmLDhcib+LM4C5IPjeiauONtmabdMh1ox0JU2BD09h9Ay+Om5qdjx8akLsdCElsFCzwuQjY1FQxCjwLPIWOwVDs7lcQTyLV0k4NXmfpJz79vIyQwavB4ZFnmBRdoe1b3D6ciS29sL7n/a2HgA2TTZFVz86kIcVNWzT3kjyH6xOvOrCfWHqKp0qEEX2jBFS89taxl09ZygM7zp6lPoWGhCy+Cg5/WUTw7eCPwU+ISjg1mWIQ5vL7h/rbl/cub6CHJE0+ya5Q9yL3b7anpUCyVdjptXP18w97YCL3FzsVF8/AodB2X17FveWciXTZ3f1EvQ+eCq0qEGodsQ9PXclpZBX88J9WPH16eQsdCElsFBz/MoD4TzkAnEV1g4dQIyhptljPH9MhcX5N2GLDPNDsO+C3mk1WQJ8ohfRY9qofwAGbPOHmN1icl7H/ZzeG3g61foOCiq5zrlrUd+j60OCTpfelU61CB0G4K+ntvQMjSj54R6sVPHp5Cx0ISWIUfPRT+/8TDymLmc/MfNjUgv4tGC/IO8DwnoTcgZaLuB1wBvR1brbEQmI7PMAE5EKmhwb8ks5LeyVluU7cImZEggb//PO80fjC8jP53xieWngc+Z/6eZtL/l4CNvPoIcuZNO4F6Q40Mfv8nqOtTxK2QcFNVznfKOBl5O/jaYEFTpUIOQbQjN6LlpLUM39VzXp1Cx0ISWwVPPq0rujVnaOBP4OXJ00LPIePtTwB3I/omiOYuFyDd4dr/I2cjJDE3wUuTRO+vTVylfVdUfSLvYXLvQ0cYB4Dc6b8OJun6NWZajHQdF9VynvJ8gYqpLgs6TXkqZDjUYs0yn3YbQnJ6b1LKNHV89J/jHjoZPY5ZlacZCE1oGPT1PeY4H3loj/zeRBpyn406kAO16zh5sHJn8RC1PDpqo56hnR+qsmNuB+9LiiDva9dzkKslIOKKWu08T9Rz1HIlEIpFIJBKJRCKRSCQSiUQikUgkEolMUv4PPtcLAlHH2usAAAAASUVORK5CYII=\n",
       "text/latex": [
        "$\\displaystyle \\left(\\sqrt{5} i\\right)^{\\alpha} \\left(\\frac{1}{2} - \\frac{2 \\sqrt{5} i}{5}\\right) + \\left(- \\sqrt{5} i\\right)^{\\alpha} \\left(\\frac{1}{2} + \\frac{2 \\sqrt{5} i}{5}\\right)$"
       ],
@@ -430,7 +430,7 @@
      "execution_count": 5,
      "metadata": {
       "filenames": {
-       "image/png": "/private/var/folders/dm/b2qnkb_n3r72slmpxlfmcjvm00lbnd/T/pytest-of-cjs14/pytest-27/test_complex_outputs_unrun0/source/_build/jupyter_execute/complex_outputs_unrun_22_0.png"
+       "image/png": "/tmp/pytest-of-choldgraf/pytest-173/test_complex_outputs_unrun0/source/_build/jupyter_execute/complex_outputs_unrun_22_0.png"
       }
      },
      "output_type": "execute_result"
@@ -441,6 +441,40 @@
     "n = sym.symbols(r'\\alpha')\n",
     "f = y(n)-2*y(n-1/sym.pi)-5*y(n-2)\n",
     "sym.rsolve(f,y(n),[1,4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive outputs\n",
+    "\n",
+    "## ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1337h4x0R",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Layout()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Layout(model_id=\"1337h4x0R\")"
    ]
   }
  ],
@@ -503,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -575,8 +609,68 @@
     "_Feature"
    ],
    "window_display": false
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "1337h4x0R": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/test_execute/test_complex_outputs_unrun.xml
+++ b/tests/test_execute/test_complex_outputs_unrun.xml
@@ -142,3 +142,17 @@
                     sym.rsolve(f,y(n),[1,4])
             <CellOutputNode classes="cell_output">
                 <CellOutputBundleNode output_count="1">
+    <section ids="interactive-outputs" names="interactive\ outputs">
+        <title>
+            Interactive outputs
+        <section ids="ipywidgets" names="ipywidgets">
+            <title>
+                ipywidgets
+            <CellNode cell_type="code" classes="cell">
+                <CellInputNode classes="cell_input">
+                    <literal_block xml:space="preserve">
+                        import ipywidgets as widgets
+                        widgets.Layout(model_id="1337h4x0R")
+                <CellOutputNode classes="cell_output">
+                    <CellOutputBundleNode output_count="1">
+    <JupyterWidgetStateNode state="{'state': {'1337h4x0R': {'model_module': '@jupyter-widgets/base', 'model_module_version': '1.2.0', 'model_name': 'LayoutModel', 'state': {'_model_module': '@jupyter-widgets/base', '_model_module_version': '1.2.0', '_model_name': 'LayoutModel', '_view_count': None, '_view_module': '@jupyter-widgets/base', '_view_module_version': '1.2.0', '_view_name': 'LayoutView', 'align_content': None, 'align_items': None, 'align_self': None, 'border': None, 'bottom': None, 'display': None, 'flex': None, 'flex_flow': None, 'grid_area': None, 'grid_auto_columns': None, 'grid_auto_flow': None, 'grid_auto_rows': None, 'grid_column': None, 'grid_gap': None, 'grid_row': None, 'grid_template_areas': None, 'grid_template_columns': None, 'grid_template_rows': None, 'height': None, 'justify_content': None, 'justify_items': None, 'left': None, 'margin': None, 'max_height': None, 'max_width': None, 'min_height': None, 'min_width': None, 'object_fit': None, 'object_position': None, 'order': None, 'overflow': None, 'overflow_x': None, 'overflow_y': None, 'padding': None, 'right': None, 'top': None, 'visibility': None, 'width': None}}}, 'version_major': 2, 'version_minor': 0}">

--- a/tests/test_execute/test_complex_outputs_unrun_nbclient.ipynb
+++ b/tests/test_execute/test_complex_outputs_unrun_nbclient.ipynb
@@ -4,6 +4,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:00.136549Z",
+     "iopub.status.busy": "2020-06-09T20:58:00.135499Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.000390Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.000658Z"
+    },
     "init_cell": true,
     "slideshow": {
      "slide_type": "skip"
@@ -158,6 +164,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:01.003529Z",
+     "iopub.status.busy": "2020-06-09T20:58:01.003122Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.005552Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.005184Z"
+    },
     "ipub": {
      "text": {
       "format": {
@@ -247,6 +259,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:01.010731Z",
+     "iopub.status.busy": "2020-06-09T20:58:01.010410Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.021093Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.020829Z"
+    },
     "ipub": {
      "code": {
       "asfloat": true,
@@ -360,6 +378,12 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:01.024117Z",
+     "iopub.status.busy": "2020-06-09T20:58:01.023659Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.026242Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.025992Z"
+    },
     "ipub": {
      "equation": {
       "label": "eqn:example_ipy"
@@ -400,6 +424,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:01.040077Z",
+     "iopub.status.busy": "2020-06-09T20:58:01.039754Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.681565Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.681305Z"
+    },
     "ipub": {
      "code": {
       "asfloat": true,
@@ -417,7 +447,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa8AAAA/CAYAAABXekf2AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAToklEQVR4Ae2d7bXdtBKGD1kUEHIruKED4FaQ0AFwKwA6gJV//MuCDsKtIEAHQAUBOoASQjrIfR8fzcbbxx+SJcuyz2gtb39Jo9E7Go1GkrXfefv27Y2H8gh88803L0T1T52/K0/dKY4hIKwf6/nPOj7U9ZuxOP7MEYhBwPU3BqWycVL190HZ7J0aCEgIX+j0kc5uuCpWCeH9l7Kj0/BjxWw9q5Mh4Pq7j0BT9deNV2E5SQAfiOS3Oj4tTNrJRSAg/LsOg87IwIMjkISA628SXMUjp+ivG6+C8Av4hyL3q46vdY0X4GEfBOg4fCEZfLJP9p7rERFw/W1GalH6+47PeZUTmCo/Q1YMF35Yjuo5KQkjPNTfY0un+O/ExiWe4mO4/qfj37r2+S9A8TCLgOqJ6+8sQv+8FFa76++7/7DjVzkIBGEy1+WGKw5IhvVYWPFHXPS0WKL7kw7y4PgyLbXHvm8IuP4mS3x3/fVhw2SZTSagl0+DuUljPJnrAV+EhuKmAlZfCx6GDx8fECZnuS4Crr+ReLeiv268IgU2F03CZIgKN5rG0sMyAs8UhZ5bF0wZ7J6znj3UkWV0lP4nkaIzwXCQB0dgFAHVE9ffUWQmHzahvz5sOCmfpBc0xL9ICZIWaSg+Bo9l3c19lyTeMBxmjD/S9Wvu9TzLswx0H+v8i+hZ+FX3LHYx2lwTJodgFf8rvX9f56UhweeK96PifaDD6EPbgyNgCLj+GhILZ+kQ7UIT+uvGa0FYS69pFBGmDmvoZ5MoPg0zQxQYA4xClneh9MVDqKDf6nxZ7q9rFPx3nT/W0Tc8qfmD0xArsOAASzoAeEzPlc/cQguMFvFmg2gwlAsd4i8Zulla/vJ8CKhuuP6mibUZ/XXjlSa4sdi40Dc0kmMvh89CQ9oZBV3jPaA8rQUM1ed9psQrXhcLUvAU3+u/i71Wegw3qzGHRuQPPbsYyhh6iv9+TLwQ5wed4X2YbwIJj3pSBFx/IwXbmv4+iOT7NNEkADwKJvG/4toKpmsa1qQQ0jBe/n1SwvYjPxWLf49ggseVMxcF3s93KH6344bKgwHzcGAEJEPX32X53Qv9nTVeqigvWlN48UPjyfDVGmPzp+T+Umm/18FODIzd4v0Q1jRsn90mPd2CAIzUX8KG4baxsAZ70jwVzSgPdSzTtc+UJ+WhLIfyvMR3c/q3VgaWTmVy/TUwtjvfC/2dHDZEcYTtI52b8irEzxsdDGkxyf+E+5g6oHiUh+Gp/qT9z3r2ZXjWfx5Dkjg2/LcmbWwe1eMJj6khvG6Ic4BhLH8Mz1w83WEi0aTzYEaRIUEa7itcdc974vE+ddPjbuhQNOiwJC2sUV7Vg3hsUv9ygVC5XH9zQVxIL4zvhf6Oel4qPA0EcxNTICzAt+1r8UWjhnKnbMCKl/RywBmN2GMdaxch4J7Tyzl9EOaTE9t694kOsJgLxJnqCGGUftD77zh0jZHDux7SfBbeI3eMYUqgo0IY0rx92tCvyti0/uVCpfK5/uaCmJhemJ9Of+8Yr1BIGo8nifhUjS4+u4ZQZxv2W8qfBvKqJ6/71zp4njwPo3ytERzSFLlTBgyGDbdeChjwZ/XknFeFjOhsjAbRoPPwxl7qmk4FnYJLGj2jk/EqxKFTleo9mZw+DjSaPKmcNDLN618ueCqn628uiGnpT6e/d4yX8KAhopG6NCZpGFWNzRwGE7g0bEuBxusST2kwWv8lEWUN99zGBvNKrUcfm+5w8YQNRoTv2K7mjHQPnjRCHHxH1Q0r6noYGJrFo0oJnVcc8iDda13bfBmeycsUYkoLPeq0dTpSkteMeyT9y8XF9TcXwYj0qvun1N93+2VXIe1L86Jel+jSqGEoYr2kG6VZ3IhVcVhUQMOJcJZ61BgblnvT4OJxMffBPRPI8EXjZo2jLhcD32gRfrs9nfNX2GAobnS+MlzhWef96N1z3YPhMx1m1IlCOtIjn9Gg9xh/5lanPkimkwGdrjOlM3WU0PXcby+jf5HVU9FA5h296JQVIoayoStF9S+XdfHl+psL4k7pJbvT6u+V8RK+DFcw71BasaGLoRh+nFpCpNBm8n52Il7vaWjHGuA7zyKZQqHnVuRFkmk3mjDDUFztYgHOcBzw7JjXNZ4rxuQLnYdyQOZThon0dALoTAzDIx6Ing332XsMpH14bM9izxhKPC+OlI5KLP3ceFvpXwm+XH9zUaycXrpzav19YHiqoDTGNEz0oouFQPdG52EjVCQP0cUoMT+y1ggl86E8uwZcCTvPI5nAARKojNSH/+g87HCgEGPGhoaXcImvtMRdMjQMUbN6cBgwMFeLYRQPLwy+XhJZ95YntzHB5LXkpcfQKhpHZdlE/3KZDHyBtetvLpgV0we5nVp/L8ZLuNKjZV6jtNcF3dRGJlXMTEZ27nFqwpXxaWgI1hje3p3kV3UA4wymDK+xZN0OnjF/daeO6Jl1IvC+MDIEZL/UGepod7HDj9Lb8PLVEKRe46Xd6D0GER75bi8lmLys85GSduu4W+lfLt+uv7kIVk4fdOP0+tsfNqSXXNR7CSAyjDTsQd/ZJFVxaPCY+7AGJkXk0KehZTl2jeEga/xSG8+uTOKxq1i66RpjnVkWTs/2lc6pCxs6moV/4I8yjnUI5nrgdFLwmDBgyPE3ne8YOj2/BOLpYNHNi/Dwkc54dnf+RFJx6FxxYNxsqDIkizpZ3TL5RSWqFKm4/uXyLZzByfV3AKRwcf0NmAiL3fS3M15iwDyJKyMzkNmaW4aQLsNIPQJJu4iLPxqrq7mXHq2bACANE8NBNYyXDXNZY9hnZ/Fa/A49isU0NSOIv7k5qklWlA7DgnGjtw42UeVUGuJGdZwUd/WQn9Ji8JRVZ5g5NxHE01b6l1s+198RBCWvqHo9krTKI/F3L/T3QUDThmNWNcZjEhGAeFJ86DxmEOlZkxdKSzwMztzfgtCwzfbg9Z58zJPR5abBeu7F8NqU27rEGSZEpvTIWsSnq0ehftZFZjq34vo3nVXcG9ffOJxOGOsw+mvDhvRm54aD1siIISSAGAtJu4hLkczTGaNlzxjCGxvmsvclzwxtEZYM6m2se/QrWTEfhdEa87hbQMI6TcgwS34qJ0OkDKutWbbfx2IL/evTX3Pt+rsGtYw0BevTai7Ew2H01zwvlLBYL1kA0PN+ChCrUUxP2PGvPG0IJp1CfArzvPAgPQwQkAwY4i1Wnwbkc29NZibDHHrUc47cUFT/cpmR7Fx/c0Fcl75UfVqXe0h1FP014wVoJRubGiuUhgIy/ks0SkPaw/uuwZKQ3wxf+H3zCJjMOhk2wi28WP1tgSXX3xak4DyMIXDRXxs2JFLUyjk12KyKYuJ7bC7LMmPV3+xQn94zxGcNCHFZMn0ZutQ174jDu5gdxE35bUhPyTw4AodBIEr/cksjvXL9zQXR0zeBwANVZvNUbDhlkjHFZdUfe69NfrcV4tiy5ylaGKalXcSfiRbLxlmWSk9wNijuxSLPRvSX9x0Bq+dNdHJUb6P1L1dwQTddf3OB9PR7InDRX4YNzfuZZSgoGRPTHFmbsIrW7C7iIa9XgSGWpZpXFR7Nnv41+zbzpXiLwiszG09+fxCoUp9cf28rlOvveRSLYUPrgZrnMlo6Cb0zIDqzghAPDG/o6nsHvWOYb8nrUpTRAH0WedATHe4gnrJyrUpjIB5n8RotYaGHwogy/qojpayfKt1lWLYQK0ckY3KLxk64UadZVDEMne7o/ZfDF7qPXVEbq39ZMhePrr/XQrJ6cP20wt3G9alCCXbNwuT2EONlbliUMgt429mAXRRYJtz3ijAysx/IKf7iLuJGU2fG5wm5S5Fvqez8q/K8jWVBcSd31dc7BDiLc2w+w3gpPA7T7nk/h1cuX6I9Zpxu9Jz6iQ7k7IoSpX/Ko4jMoaMDfXL9TawYwq2U/m5Wn1J4TCz+ptHF92R7N5Vxf8HGVJyx58x54WVhrDpBKHMUmW8EzDLqdjR8pKemsP0I1ovtewd4dzE0b5SvGd8qE999xmOvxWOygGJpl4p3BB5LlfUe03H9XSH8I+jGEXhcAf1oEua8zNjY8MVoxP5DAYS3xWpDem9mNDA0z/vxJq6jdhEPdD8QjZfQ0f3kIpGQj/Fv5QmPy57Eh9G3cpfNwKltjYDJzeS4dX5L9I0Pq79L8bPfqw67/qYNuWdj7gSKIXDRX4yXeUH2MDYXMyYYMLyu33oN+xyN2F3E8dBuRBPPi3mwJY/K+LfyzPHg7xyBVhCw+mr1txZfrr+1kPZ8NkGApfJvRJlj9rusYe5Kh+fFEB8eF4cpgy6ng9LR6+t2Edc1hoyl8OR9tYt4oG87iLOQY2ney3qulMWDIzCFgNUTMxpT8ao8V71epX+5zAX9cv3NBdLT10bgor8254VBwbtJDQwTYnySNmGV4pDf6KRlnwHFS9lB3Pj/rU9jo2sanIcb0T4NWcmv9F/flMCmRbmt1b9cPFx/cxE8cfrW9deMFw3+Z6lyUOEY0kPxUpayp2YTG5/VdxhRDMvWgV77Q+XFkZyf0mBoDTNbwMLfrNMTPlNI+uubygWn3uYGZJ8s/5FMV+nfCJ2kR6pvrr9t6W+p+pRUD2YiN62/Zrx+VwG6xRepjbHiJw03zgCV++qpCNRq/K2njAub1HgJLwwXw6aXb+R0zZArf0jJx9tz224p2qECRp7jAx1gxkbNz1XGJMyUpmQwDz2bh4KyWq1/ucCoDK6/CSAKr830t2B9SijRbNSm9deM1w8qwgsdGAAamEMFCf2hGO4qVSXGrddOnnYdmzWG6vN+ZPGP18WnBwzBvtd/d/Dr2A91axazGzMX3qly25LHQ+tfLjCuv7kIbpa+af19QLFVeeiF0uNPmWMiaSsBo0uo5bVYrx3jlRrg9e+gsP208M4w5BqafTp+PY8AHR2T33zMSm9PoH+5SLn+5iJ4f9Jf9LczXqHc9PqT570awaz7Mz81ArV607Zsf82QC0Zqbm4O4XjYAIFex4DhkNbCkfUvF0vX31wE70H6of6+2ytzN3ShCCxLr+XB9LLPusToXg3FZVFbTmxGMtlLEraXua5BNswL3ej9H4Pnh75VeRgONYOMsb/665vKhTN5tYjxkfUvV4yuv7kIbpS+Zf29eF5ikqGU73REfa+1EVbJZMX3VyTSueZcHavDCNYY3t6t/BXvGC5o2QrElZSaS4bRWvrrm5pMm7xe1cw0Ji/VgUPqX0zZ5uKo3K6/cwDt+65p/b0YLzBSRaLxZKPRzgvYF7fo3PlAuqbXBU40NHhfpXBiyIhts+g8nCaoPLN/fbNDQW0z4yZHFoTXEfUvV4yuv7kIbpS+df29Ml4BAxSIP6xrPghcem3MH9X0ugyXrgFU3tabt+dJZ6VnlSc7iSx+tJ1EuN3IGH06SFm4rSyebTnW4rChFekw+mcMrz2rDrj+rgVvv3TN6O8d46UK1W3DFCrWfhAt5BwaP3ptU3NICxSyX/NtDsFWSt3eJfyqDMwH3eh8OsOlMv2swzAaQ4UhidoBT9nmK2vnHZWfMDuE/kUVZiaSyknnxfV3BqM9Xx1Bf+8YrwDYE52/DBVsTwxH8xZfNHz8L9jnut6rMbKhJxuKGuV16qH4ZjPj93W+GC5d7+WRTLGZ8xwvZ8xAPYKoylrV+1F+NsS7h5eeimPT+pdamGF8ycL1dwhKe/fN6++o8VLleiMsWb76Y6horUHLHBG7VOzWEClvjCY4JXteSktD+h+dGSLqBwza6/6DA19H/fVNxfKZnF5WzHNVVqoXrevfqnL1Ern+9sBo9LJ5/R01XoApBaJxZkgO976ZIL7otWG4lnaZr8EzPOAtwVNUUFzwRHn5ILn7e5hw5hneLg3XGULsX9/UKiudsTfCt6rHt7Zw4rNJ/VtbHkuncrn+Ghhtn5vX3/53XnegDAp05/meD8QTjbsN2e3JCnmz2IJJZ+auYlcKYqQwYN18l879cIiGtc/w1DV1R0f31zchDsOFeJVXf30zlb7kc/FBg4nntZunvqY8YLgmXctpVCbX35YFFHij7uloWn/fefv27QGgbJdFCbhblKDzqrmvdkt2Hs4kGzoKdDQ+1PVpOgjnkdB+JXH93Q/72Jyn9Hdy2DCWsMfrGkX+t6qp4VWXyxUCLIqhJ+mG6woWvxECdGpcf9uuCqP668YrX2hs60O4rBq8vfXfFhAInQoWyBxq55gWsLsnPLj+NizoOf1145UpOIHLGD4LN8bmsDKpe/ICCHSdCsmphQU+BYrjJEoi4PpbEs1NaE3qrxuvMniz5J3Vg90+bWVIOpVcBCQPFmogk+EnCbmkPf25EHD9bVCeS/rrxquA0ELvDQVgxwAP7SDAUCFzXbErQdvh3DmphoDrbzWoUzOa1V83XqlwTsQPDeRrnd37msCo5mPJ4bHyYyjX5yJrAn/QvFx/2xJcjP668SorMxpKvo2g4fSwLwL02n6SLFr5JnBfNDz3GARcf2NQqhNnUX/deBUURGgoGaLiQ2QPOyEgOeBx8VFy1b/K2am4nm0hBFx/CwGZSSZWf/0j5Uygx5ILfDYNZld1n2sZA2jDZ8Icr5cPx5/o2r/r2hDrs5J2/d1Psin6657XNnJiT0j2KbSdzLfJxamOIYDX+7UbrjFo/FkkAq6/kUBtEC1af914bYC+Gk6+/WIjWPbz81AJAeHO0ngMl3/TVQnzM2bj+ruPVFP19/8PVQ3F1sRV/AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb0AAAAeCAYAAAC40cCwAAAABHNCSVQICAgIfAhkiAAACc1JREFUeJztnXusHUUdxz+9vdAKtVBfNOLjFos8JNDQlohiOVWkNharaDU+0DUaY2IhikYFi68YX9iAGqEEgqBSRRIgKZY/QDAtjaiEVklaFZEjITwCEtqirUpb//jN5p7u3cfM7G939t4zn+Tm3OzO/OZ3Zn7fc2bndSASiUQikQgA00M7kEMbPs1ooYxItzg0tAMldFGHWjT93qKWh5NCPY+UZBoBzvco7IDyX5blwHwPv2w5BzijQfvDwuE0GwfaLADe1kI5rvjqUIOmtQzN6jlqWY82YkETLz1/CzjRMc9C4JOuBTkyDfgxcGQDtk8Arm3A7rDRRhw0wVrglNBOZPDRoQZttWFTeo5a1mMo9PxGk8GVLwOv9MjnyiLgh8o2R4B7gLnKdoeRtuJAmyOALXRnONFXhxq02Ybaeo5a1mUo9LwJ6Sm5co1HHl/+AIwp2vso8AtFe8NMm3GgzVXAx0I7YfDVoQZtt6GmnqOWdZnyel4G/N7D+FHANzzy+fJZ9BpjGvBX4Gwle8NM23GgzWnAo8DMwH746lCDEG2opeeoZV2GQs83At/1MJ4Ab/DI58tiYDdwmIKtpcBeYFTB1rCT0G4cNME/gfcG9sFXhxoktN+GWnqOWtYlYYrreTqwE3i/h+ErKV8Nqs1M4Hlk9VceC4FfA3uAvwFLkDe+JSftj5DhlUh92o6DJrgT+GXA8uvoUIMQbVim56jlcEw5PWffzEnAbOCPjkYPAfYB+2u5VsyFyDLXDwxc24sMY+T1QhYDm4G7gZOBe4GvAV8CLslJfyawVdHfYSVEHDTB/UhMhMJXhxqEasMiPUcth2NK6jn7pXeceX3K0egZyGqpIvoU79d4wsL+IvN6X+b608Brc9KvBTYgY9EPAuuR3uEzwF2ZtIciiwX6JeW/B1ldthnYZfz+mYXfIGPi+0z+jwO3IL3VPUhv/h5kojVUb+rFin6FigM4uJ7rlvcP4GXGZgh8dahByDbM03NXtaypGy20fQoVC5pahoyes+PeR5vXXRYOD7IM+E5Fmp3A5TnXn7Ow/0Xg60jQD7KLcZ9T5gJvQsb2U/6LNHhez/DV5t7OkvLXIPs9nkMmRY+38DllpbG/HbgaeBzptT6CNMK5yAT+cmAV7WzcHGQVMoSh4VeoOIDxer5Zobw0FuYBT1r4pY2vDjUI2YZZPXdVyzejqxsttH0KFQuaWk7zQYGe1wD/Kck8Qv4E8VUVhfYp7335cgMThzKWIo06a+Dap4A/F9g4zaQ/r6ScpcCxyMqwHm69w9uRHuxbkBMisr2tuUhwHgDebWlTkzfj7lfX4gDG63lwT45vee9A3rfvCS2Jyd/zzF+lQw262IZZPXdVy9Px040NCf6x4+tT12JBU8uQ0XO2cvbnXEuZA2wEPpi5fgzwkKczNqSBf2nOvVHkMXiQI0369PoLkfH/fxfYT8/mK7oP0mt6EPde22wkEDcgE/EbmDg+/gSwzvzfc7SvwV24+dXFOBis52w8+JDGQqhtC2U61KCLbQgT9dxVLe/DXTdt4ONT12JBW8uQ0XP22323uXYYEwPndcij4Qrg+oHrK4BfWRQ8A/gQ8CrgX8CfkM23VW/sVPN6f8692cbnQbYhvbiLkJ7jpcjj/nykh5d9lN5jXmehzwpknuGWinT/M6/PN+BDHfL86mIclNWzT3lpLOwpSdMkZTrUoIttCBP1PBm1DN3Uc5FPXYsFbS1DhZ5XIt++Rcf3HIuMjx4ycG1dQdpB+uRPQP6d6lVyN5i0x+Xc28LBDZVyMbIIYK/JP8ekzVsYcIyxb3uobw/7IZGbkPHmsieGUeABY3OZpQ9tUOZX1+KgqJ59y/uwSbeoJE0ZCfWGN6t0qEHX2hDy9TyZtAz19ZxQL3byqPKpS7GgrWWo0PN8c3NhiYG/IPNTICfp25wN+BXkkfUopPd6ElKp+5GebNmhoDuQ3t+0nHsPA5+3KL+MUaQXtMYyfQ87ocxE/L6pIt33jD2bXlWbVPnVlTgoq2ff8s5H3vucqjdUQEK9Dy4bHWrQlTZMqavn0FqG+npO0P/Ss/GpC7HQhJbBQs+PI8tei1gLXGb+X0nx5nAb0sYoGjI4HHl03ZxzLx3vP71G+Slbgess0/awE8o5VO9BucCk2QG8yLL8PsVLd/P+bCfpXf3qShzY1LNred9HPoBt6OPWHtdZ2i3ToWuZRTHQlTYEPT2H0jK467lPM7Hj41MXYqEJLUNGz3krdm5lfLw1j9uQVT2fQYLmIgcHs6xDztxbUnD/FGRCP28OYAHwGPC7GuWn3A2cpWBnkHOR5dVFvavVSGNsR3pYz1jafQgZ6rHlMYe0Ln51JQ6q6tmnvFORmLDhcib+LM4C5IPjeiauONtmabdMh1ox0JU2BD09h9Ay+Om5qdjx8akLsdCElsFCzwuQjY1FQxCjwLPIWOwVDs7lcQTyLV0k4NXmfpJz79vIyQwavB4ZFnmBRdoe1b3D6ciS29sL7n/a2HgA2TTZFVz86kIcVNWzT3kjyH6xOvOrCfWHqKp0qEEX2jBFS89taxl09ZygM7zp6lPoWGhCy+Cg5/WUTw7eCPwU+ISjg1mWIQ5vL7h/rbl/cub6CHJE0+ya5Q9yL3b7anpUCyVdjptXP18w97YCL3FzsVF8/AodB2X17FveWciXTZ3f1EvQ+eCq0qEGodsQ9PXclpZBX88J9WPH16eQsdCElsFBz/MoD4TzkAnEV1g4dQIyhptljPH9MhcX5N2GLDPNDsO+C3mk1WQJ8ohfRY9qofwAGbPOHmN1icl7H/ZzeG3g61foOCiq5zrlrUd+j60OCTpfelU61CB0G4K+ntvQMjSj54R6sVPHp5Cx0ISWIUfPRT+/8TDymLmc/MfNjUgv4tGC/IO8DwnoTcgZaLuB1wBvR1brbEQmI7PMAE5EKmhwb8ks5LeyVluU7cImZEggb//PO80fjC8jP53xieWngc+Z/6eZtL/l4CNvPoIcuZNO4F6Q40Mfv8nqOtTxK2QcFNVznfKOBl5O/jaYEFTpUIOQbQjN6LlpLUM39VzXp1Cx0ISWwVPPq0rujVnaOBP4OXJ00LPIePtTwB3I/omiOYuFyDd4dr/I2cjJDE3wUuTRO+vTVylfVdUfSLvYXLvQ0cYB4Dc6b8OJun6NWZajHQdF9VynvJ8gYqpLgs6TXkqZDjUYs0yn3YbQnJ6b1LKNHV89J/jHjoZPY5ZlacZCE1oGPT1PeY4H3loj/zeRBpyn406kAO16zh5sHJn8RC1PDpqo56hnR+qsmNuB+9LiiDva9dzkKslIOKKWu08T9Rz1HIlEIpFIJBKJRCKRSCQSiUQikUgkEolMUv4PPtcLAlHH2usAAAAASUVORK5CYII=\n",
       "text/latex": [
        "$\\displaystyle \\left(\\sqrt{5} i\\right)^{\\alpha} \\left(\\frac{1}{2} - \\frac{2 \\sqrt{5} i}{5}\\right) + \\left(- \\sqrt{5} i\\right)^{\\alpha} \\left(\\frac{1}{2} + \\frac{2 \\sqrt{5} i}{5}\\right)$"
       ],
@@ -430,7 +460,7 @@
      "execution_count": 5,
      "metadata": {
       "filenames": {
-       "image/png": "/private/var/folders/dm/b2qnkb_n3r72slmpxlfmcjvm00lbnd/T/pytest-of-cjs14/pytest-846/test_complex_outputs_unrun_nbc0/source/_build/jupyter_execute/complex_outputs_unrun_22_0.png"
+       "image/png": "/tmp/pytest-of-choldgraf/pytest-170/test_complex_outputs_unrun_nbc0/source/_build/jupyter_execute/complex_outputs_unrun_22_0.png"
       }
      },
      "output_type": "execute_result"
@@ -441,6 +471,47 @@
     "n = sym.symbols(r'\\alpha')\n",
     "f = y(n)-2*y(n-1/sym.pi)-5*y(n-2)\n",
     "sym.rsolve(f,y(n),[1,4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive outputs\n",
+    "\n",
+    "## ipywidgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2020-06-09T20:58:01.684186Z",
+     "iopub.status.busy": "2020-06-09T20:58:01.683879Z",
+     "iopub.status.idle": "2020-06-09T20:58:01.707915Z",
+     "shell.execute_reply": "2020-06-09T20:58:01.708169Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1337h4x0R",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Layout()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "widgets.Layout(model_id=\"1337h4x0R\")"
    ]
   }
  ],
@@ -503,7 +574,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.3"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -575,8 +646,68 @@
     "_Feature"
    ],
    "window_display": false
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "1337h4x0R": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "1.2.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "1.2.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "overflow_x": null,
+       "overflow_y": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tests/test_execute/test_complex_outputs_unrun_nbclient.xml
+++ b/tests/test_execute/test_complex_outputs_unrun_nbclient.xml
@@ -142,3 +142,17 @@
                     sym.rsolve(f,y(n),[1,4])
             <CellOutputNode classes="cell_output">
                 <CellOutputBundleNode output_count="1">
+    <section ids="interactive-outputs" names="interactive\ outputs">
+        <title>
+            Interactive outputs
+        <section ids="ipywidgets" names="ipywidgets">
+            <title>
+                ipywidgets
+            <CellNode cell_type="code" classes="cell">
+                <CellInputNode classes="cell_input">
+                    <literal_block xml:space="preserve">
+                        import ipywidgets as widgets
+                        widgets.Layout(model_id="1337h4x0R")
+                <CellOutputNode classes="cell_output">
+                    <CellOutputBundleNode output_count="1">
+    <JupyterWidgetStateNode state="{'state': {'1337h4x0R': {'model_name': 'LayoutModel', 'model_module': '@jupyter-widgets/base', 'model_module_version': '1.2.0', 'state': {'_model_module': '@jupyter-widgets/base', '_model_module_version': '1.2.0', '_model_name': 'LayoutModel', '_view_count': None, '_view_module': '@jupyter-widgets/base', '_view_module_version': '1.2.0', '_view_name': 'LayoutView', 'align_content': None, 'align_items': None, 'align_self': None, 'border': None, 'bottom': None, 'display': None, 'flex': None, 'flex_flow': None, 'grid_area': None, 'grid_auto_columns': None, 'grid_auto_flow': None, 'grid_auto_rows': None, 'grid_column': None, 'grid_gap': None, 'grid_row': None, 'grid_template_areas': None, 'grid_template_columns': None, 'grid_template_rows': None, 'height': None, 'justify_content': None, 'justify_items': None, 'left': None, 'margin': None, 'max_height': None, 'max_width': None, 'min_height': None, 'min_width': None, 'object_fit': None, 'object_position': None, 'order': None, 'overflow': None, 'overflow_x': None, 'overflow_y': None, 'padding': None, 'right': None, 'top': None, 'visibility': None, 'width': None}}}, 'version_major': 2, 'version_minor': 0}">


### PR DESCRIPTION
This fixes ipywidgets by putting the widgetstatenode inside the doctree rather than prepending to the very top of it (which was causing widgets to be missed because they came before `docinfo`). It also adds a basic test for widgets.

note: I'm adding a new notebook to our test suite (`interactive.ipynb`) because ipywidgets randomly generates widget model IDs and this was causing our regression tests to fail. I think it may also be worth having a notebook specifically for interactive outputs as these can be more complex than traditional outputs.

You can see the widgets working here: https://506-241268229-gh.circle-artifacts.com/0/html/examples/interactive.html#ipywidgets

closes #192 
closes https://github.com/executablebooks/jupyter-cache/issues/31