### PR TITLE
adding code cell directive for warning

### DIFF
--- a/docs/use/markdown.md
+++ b/docs/use/markdown.md
@@ -21,7 +21,12 @@ directly into the {ref}`Execution and Caching <execute/cache>` machinery!
 [^download]: This notebook can be downloaded as
             **{jupyter-download:notebook}`markdown`** and {download}`markdown.md`
 
-They are distinguished from standard Markdown files by adding this top matter to the first line of you file (or the relevant `kernelspec` for your code):
+
+(myst-nb/jupytext-metadata)
+## Jupytext metadata
+
+In order to signal MyST-NB that it should treat your markdown file as a notebook,
+add the following Jupytext front-matter to the beginnign of the markdown file.
 
 ```md
 ---
@@ -34,9 +39,19 @@ kernelspec:
 ---
 ```
 
+Note that `kernelspec:` should map on to the kernel you wish to use to run your
+notebook's code. It must be installed on the machine and registered with Jupyter to
+be used.
+
 ```{tip}
-You can also create the file from an existing notebook: `jupytext notebook.ipynb --to myst`
+Jupytext allows you to convert back-and-forth between `.ipynb` and MyST-markdown
+notebooks.
+
+* To convert `.ipynb` to MyST-markdown, run: `jupytext notebook.ipynb --to myst`
+* To convert MyST-markdown to `.ipynb`, run: `jupytext mystfile.md --to ipynb`
 ```
+
+## Supported source files
 
 By default the `myst_nb` extension will look for both `.ipynb` and `.md` file extensions,
 treating markdown files with the above front matter as notebooks, and as standard
@@ -53,7 +68,9 @@ source_suffix = {
 }
 ```
 
-The following syntax can then be used to define a code cell:
+## Syntax for code cells
+
+When writing notebooks in pure-markdown, use the following syntax to define a code cell:
 
 ````md
 ```{code-cell} ipython3
@@ -63,7 +80,11 @@ print(f"{a} {b}")
 ```
 ````
 
-Yielding the following:
+The argument after `{code-cell}` (above, `ipython3`) is optional, and is used for
+readability purposes. The content inside `{code-cell}` makes up the content of the cell,
+and will be executed at build time.
+
+This will result in the following output after building your site:
 
 ```{code-cell} ipython3
 a = "This is some"
@@ -71,6 +92,10 @@ b = "Python code!"
 print(f"{a} {b}")
 ```
 
+## Parameterizing your code cell
+
+You can begin your `code-cell` block with front-matter metadata. These will be used
+as **cell-level metadata** in the resulting notebook cell.
 The same metadata tags can be used as you would in a normal notebook,
 for example those discussed in {ref}`use/hiding/code`:
 

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -3,6 +3,7 @@ __version__ = "0.8.1"
 from pathlib import Path
 
 from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
 from sphinx.util import logging
 
 from jupyter_sphinx.ast import (  # noqa: F401
@@ -78,6 +79,26 @@ def update_togglebutton_classes(app, config):
 
 def save_glue_cache(app, env):
     NbGlueDomain.from_env(env).write_cache()
+
+
+class CodeCell(SphinxDirective):
+    """Raises a warning if it is triggered, it should not make it to the doctree."""
+
+    optional_arguments = 1
+    final_argument_whitespace = True
+    has_content = True
+
+    def run(self):
+        LOGGER.warning(
+            (
+                "Found a `code-cell` directive. To execute the `code-cell`, you must "
+                "add Jupytext header content to the page. See "
+                "https://myst-nb.readthedocs.io/en/latest/use/markdown.html "
+                "for more information."
+            ),
+            location=(self.env.docname, self.lineno),
+        )
+        return []
 
 
 def setup(app):
@@ -160,6 +181,7 @@ def setup(app):
     app.add_js_file("mystnb.js")
     app.setup_extension("jupyter_sphinx")
     app.add_domain(NbGlueDomain)
+    app.add_directive("code-cell", CodeCell)
 
     # TODO need to deal with key clashes in NbGlueDomain.merge_domaindata
     # before this is parallel_read_safe

--- a/tests/notebooks/basic_nometadata.md
+++ b/tests/notebooks/basic_nometadata.md
@@ -1,0 +1,9 @@
+# a title
+
+this was created using `jupytext --to myst tests/notebooks/basic_unrun.ipynb` but
+with the jupytext metadata removed.
+
+```{code-cell} ipython3
+a=1
+print(a)
+```

--- a/tests/test_text_based.py
+++ b/tests/test_text_based.py
@@ -38,3 +38,14 @@ def test_basic_run_exec_off(sphinx_run, file_regression, check_nbs):
 
     file_regression.check(sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb")
     file_regression.check(sphinx_run.get_doctree().pformat(), extension=".xml")
+
+
+@pytest.mark.sphinx_params(
+    "basic_nometadata.md",
+    conf={"jupyter_execute_notebooks": "off", "source_suffix": {".md": "myst-nb"}},
+)
+def test_basic_nometadata(sphinx_run, file_regression, check_nbs):
+    """A myst-markdown notebook with no jupytext metadata should raise a warning."""
+    sphinx_run.build()
+    # print(sphinx_run.status())
+    assert "Found a `code-cell` directive." in sphinx_run.warnings()


### PR DESCRIPTION
This adds a code cell directive that simply raises a warning about the code cell, and then returns nothing (so the content won't make it into the final page). I thought about making it parse the content as "literal" but for now it seemed reasonable to just raise the warning and make it "obvious" that there was an error in the end-product, which I think will increase the likelihood that people look through the logs for errors.

Also cleaned up the "myst markdown notebooks" section a little bit

What do folks think?

closes https://github.com/executablebooks/MyST-NB/issues/182