### PR TITLE
adding more explanation of myst notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,12 @@ master_doc = "index"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["myst_nb", "sphinx_togglebutton", "sphinx_copybutton"]
+extensions = [
+    "myst_nb",
+    "sphinx_togglebutton",
+    "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -51,10 +56,16 @@ html_theme_options = {
     "github_url": "https://github.com/executablebooks/myst-nb",
     "repository_url": "https://github.com/executablebooks/myst-nb",
     "repository_branch": "master",
-    "expand_sections": ["use/index"],
     "use_edit_page_button": True,
     "path_to_docs": "docs/",
 }
+
+intersphinx_mapping = {
+    "jb": ("https://jupyterbook.org/", None),
+    "myst": ("https://myst-parser.readthedocs.io/en/latest/", None),
+}
+
+intersphinx_cache_limit = 5
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@
 
 **Read, write, and execute Jupyter Notebooks in Sphinx**
 
-`MyST-NB` is an open source tool for working with Jupyter Notebooks in the
+`MyST-NB` is a reference implementation of MyST Markdown Notebooks, and
+an open source tool for working with Jupyter Notebooks in the
 Sphinx ecosystem. It provides the following primary features:
 
 * **{ref}`Parse ipynb files in Sphinx<installation>`**. Directly convert Jupyter
@@ -63,21 +64,22 @@ For information on using and configuring MyST-NB, as well as some examples of no
 outputs, see the pages below:
 
 ```{toctree}
-use/index.ipynb
+use/index
+use/markdown
 ```
 
 In addition, here is a reference page that uses the `jupyter-sphinx` package to create
 outputs, to compare how these outputs look relative to the MyST-NB style.
 
 ```{toctree}
-examples/index.md
+examples/index
 ```
 
 Finally, here is documentation on contributing to the development of MySt-NB
 
 ```{toctree}
 :titlesonly:
-develop/index.md
+develop/index
 GitHub Repo <https://github.com/executablebooks/myst-nb>
 ```
 

--- a/docs/use/index.md
+++ b/docs/use/index.md
@@ -1,13 +1,14 @@
-# Use and customize
+# Using with Sphinx
 
-A collection of example pages to see how notebook content is rendered
-in Sphinx with MyST-NB.
+These sections cover how to use MyST-NB with your Sphinx sites.
+They cover how to use Jupyter Notebooks with MyST markdown, as well as
+[MyST Markdown Notebooks](markdown.md), in your Sphinx site.
 
 ```{toctree}
 :maxdepth: 1
+start
 myst
 hiding
 execute
 glue
-markdown
 ```

--- a/docs/use/markdown.md
+++ b/docs/use/markdown.md
@@ -10,67 +10,78 @@ kernelspec:
   language: python
   name: python3
 ---
-# Notebooks as Markdown
+# MyST Markdown Notebooks
 
-MyST-NB also provides functionality for writing notebooks in a text-based format,
-utilising the [MyST Markdown format](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown) outlined in [jupytext](https://jupytext.readthedocs.io).[^download]
-These files have a 1-to-1 mapping with the notebook, so can be opened as notebooks
-in Jupyter Notebook and Jupyter Lab (with jupytext installed), and are also integrated
+MyST Markdown Notebooks allow you to write your Jupyter Notebook
+entirely in markdown using the
+[MyST Markdown format](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown).
+This allows you to store notebook metadata,
+markdown, and cell inputs in a text-based format that is easy
+to read and use with text-based tools.
+
+MyST Notebooks can be [parsed directly into Sphinx](myst-nb/sphinx)
+with the `myst_nb` Sphinx extension, and are similarly-supported as
+[Jupyter Book inputs as well](myst-nb/jupyter-book). [^download]
+
+MyST Notebooks have a 1-to-1 mapping with the notebook, so can be
+[converted to `.ipynb` files](converting-ipynb) and
+[opened as notebooks in Jupyter interfaces](myst-nb/jupyter-interfaces) (with jupytext installed).
+When used with Sphinx, MyST Notebooks are also integrated
 directly into the {ref}`Execution and Caching <execute/cache>` machinery!
 
 [^download]: This notebook can be downloaded as
             **{jupyter-download:notebook}`markdown`** and {download}`markdown.md`
 
+## The MyST Notebook Structure
 
-(myst-nb/jupytext-metadata)=
-## Jupytext metadata
+MyST Markdown Notebooks (or MyST Notebooks for short) have
+three main types of content: **markdown** (that can be written as
+CommonMark or MyST Markdown), **code cells** (that are written
+with MyST Markdown `code-cell` directive syntax), and cell/notebook
+metadata (that are written as YAML wrapped in `---`). Here is an
+example with these main syntax pieces:
 
-In order to signal MyST-NB that it should treat your markdown file as a notebook,
-add the following Jupytext front-matter to the beginnign of the markdown file.
-
-```md
+````md
 ---
-jupytext:
-  text_representation:
-    format_name: myst
 kernelspec:
   display_name: Python 3
   name: python3
+notebookmetadatakey: val
+notebookmetadatakey2: val2
 ---
+
+# Markdown content is written as regular markdown
+
+You can also write {ref}`MyST Markdown <myst>`.
+
+```{code-cell}
+---
+cellmetadatakey: val1
+---
+print("Here is a Python cell")
 ```
 
-Note that `kernelspec:` should map on to the kernel you wish to use to run your
-notebook's code. It must be installed on the machine and registered with Jupyter to
-be used.
+And here is more markdown.
 
-```{tip}
-Jupytext allows you to convert back-and-forth between `.ipynb` and MyST-markdown
-notebooks.
++++
 
-* To convert `.ipynb` to MyST-markdown, run: `jupytext notebook.ipynb --to myst`
-* To convert MyST-markdown to `.ipynb`, run: `jupytext mystfile.md --to ipynb`
+Separate markdown cells with `+++` lines.
+
+```{code-cell}
+:cellmetadatakey: val1
+print("Another code cell with a second optional metadata syntax")
+```
+````
+
+```{note}
+The kernel that your code cells use is determined by the notebook-level
+metadata for your MyST Notebook file. If no kernel is given, then the default kernel
+will be used.
 ```
 
-## Supported source files
+### Syntax for code cells
 
-By default the `myst_nb` extension will look for both `.ipynb` and `.md` file extensions,
-treating markdown files with the above front matter as notebooks, and as standard
-markdown files otherwise. You can also change which files are parsed by MyST-NB using
-the [source_suffix](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix)
-option in your `conf.py`, e.g.:
-
-```python
-extensions = ["myst_nb"]
-source_suffix = {
-    '.rst': 'restructuredtext',
-    '.ipynb': 'myst-nb',
-    '.myst': 'myst-nb',
-}
-```
-
-## Syntax for code cells
-
-When writing notebooks in pure-markdown, use the following syntax to define a code cell:
+When writing MyST Notebooks, use the following syntax to define a code cell:
 
 ````md
 ```{code-cell} ipython3
@@ -92,17 +103,51 @@ b = "Python code!"
 print(f"{a} {b}")
 ```
 
-## Parameterizing your code cell
+### Syntax for markdown
 
-You can begin your `code-cell` block with front-matter metadata. These will be used
+Anything in-between code cells will be treated as markdown. You can use any markdown
+that is valid MyST Markdown. If you are using MyST Notebooks with the `myst_nb` Sphinx
+extension, you can write Sphinx directives and roles. However, note that most Jupyter
+Notebook environments may not be able to render MyST Markdown syntax.
+
+**To denote a break between two markdown cells**, use the following syntax:
+
+```
+Some markdown
++++ {"optionalkey": "val"}
+More markdown
+```
+
+This will result in two markdown cells in the resulting notebook. The key:val pairs
+specified in the `{}` brackets will be cell-level metadata in the second markdown cell.
+
+### Notebook-level metadata
+
+You can begin the MyST Notebook file with front-matter metadata. These will be used
+as **notebook-level metadata** for the resulting Jupyter Notebook. This metadata takes
+the following form:
+
+```md
+---
+key1: val1
+key2: val2
+---
+# Notebook title
+...
+```
+
+### Cell-level metadata
+
+You can begin `code-cell` blocks with front-matter metadata. These will be used
 as **cell-level metadata** in the resulting notebook cell.
 The same metadata tags can be used as you would in a normal notebook,
 for example those discussed in {ref}`use/hiding/code`:
 
 ````md
 ```{code-cell} ipython3
-:tags: [hide-output]
-
+---
+tags: [hide-output]
+---
 for i in range(20):
     print("Millhouse did not test cootie positive")
 ```
@@ -111,13 +156,25 @@ for i in range(20):
 Yields the following:
 
 ```{code-cell} ipython3
-:tags: [hide-output]
-
+---
+tags: [hide-output]
+---
 for i in range(20):
     print("Millhouse did not test cootie positive")
 ```
 
-and `raises-exception` means our code will execute without halting the kernel:
+There is also an **alternative short-hand syntax** for cell-level metadata. This takes
+the following form:
+
+````md
+```{code-cell}
+:key: val
+print("hi")
+```
+````
+
+For example, the following syntax adds a `raises-exception` tag to the cell, which
+means our code will execute without halting the kernel:
 
 ````md
 ```{code-cell} ipython3
@@ -132,3 +189,87 @@ raise ValueError("oopsie!")
 
 raise ValueError("oopsie!")
 ```
+
+(converting-ipynb)=
+## Convert between `ipynb` and MyST Notebooks
+
+MyST Notebooks can be converted back-and-forth from `ipynb` files using
+[jupytext](https://jupytext.readthedocs.io), a Python library for two-way
+conversion of `ipynb` files with many text-based formats.
+
+* To convert `.ipynb` to MyST-markdown, run: `jupytext notebook.ipynb --to myst`
+* To convert MyST-markdown to `.ipynb`, run: `jupytext mystfile.md --to ipynb`
+
+For more information, see the [Jupytext Documentation](https://jupytext.readthedocs.io).
+
+(myst-nb/sphinx)=
+## MyST Notebooks in Sphinx
+
+In order to signal MyST-NB that it should treat your markdown file as a notebook,
+add the following Jupytext configuration to your notebook-level metadata (by adding it to
+the YAML front-matter at the beginning of the file).
+
+```md
+---
+jupytext:
+  text_representation:
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+```
+
+Note that `kernelspec:` should map on to the kernel you wish to use to run your
+notebook's code. It must be installed on the machine and registered with Jupyter to
+be used.
+
+Here's an example of a simple MyST Notebook written for Jupytext and the `myst_nb`
+Sphinx extension:
+
+````md
+---
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: '0.8'
+    jupytext_version: 1.4.1+dev
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# My simple notebook
+
+Some **intro markdown**!
+
+```{code-cell} ipython3
+:tags: [mytag]
+
+print("A python cell")
+```
+
+## A section
+
+And some more markdown...
+````
+
+For more information, see [the MyST-NB Sphinx extension documentation](index.md).
+
+(myst-nb/jupyter-book)=
+## MyST Notebooks in Jupyter Book
+
+In addition to using MyST Notebooks with Sphinx, you may also use them with the
+Jupyter Book project. See {doc}`jb:content-types/myst-notebooks`.
+
+
+(myst-nb/jupyter-interfaces)=
+## MyST Notebooks in Jupyter interfaces
+
+You can use MyST Notebooks in Jupyter interfaces by using Jupytext extensions. This
+allows you to open a MyST Markdown Notebook as a "regular" Jupyter Notebook in
+Jupyter Lab and the Classic Notebook interface. For more information, see
+[the Jupytext documentation](https://jupytext.readthedocs.io).

--- a/docs/use/myst.md
+++ b/docs/use/myst.md
@@ -1,4 +1,15 @@
-# Writing MyST Markdown
+# Write your notebook content
+
+Once activated, the MyST-NB Sphinx extension will automatically parse both
+markdown (`.md`) and Jupyter notebooks (`.ipynb`) into your Sphinx site. If your
+markdown files have [Jupytext metadata for MyST Notebooks](myst-nb/sphinx),
+they will be converted to notebooks and optionally executed.
+
+In any of these files, you may write [MyST Markdown](https://myst-parser.readthedocs.io).
+This is an extension of CommonMark markdown that provides extra syntax for common
+workflows in publishing, and extension points for extra functionality.
+
+## Writing MyST Markdown
 
 MyST Markdown is a flavor of markdown that gives you full access to all of the
 functionality provided by Sphinx (such as roles and directives). In MyST-NB, this
@@ -13,10 +24,19 @@ If you are using MyST-NB in your documentation, do not activate `myst-parser`. I
 be automatically activated by `myst-nb`.
 ```
 
-## Writing MyST Markdown
-
 For more information about what you can write with MyST Markdown, see the
 [MyST Parser syntax guide](https://myst-parser.readthedocs.io/en/latest/using/syntax.html).
+
+## Write notebooks in pure markdown
+
+In addition to supporting MyST Markdown inside of `.md` and `.ipynb` files, you can
+also write Jupyter Notebooks entirelly with markdown by using
+[MyST Markdown Notebooks](markdown.md). MyST Notebooks have a similar structure
+to Jupyter Notebooks (`.ipynb`), but they are written with MyST Markdown syntax to
+be easier to use with text editors.
+
+To use MyST Notebooks with `myst_nb`, you'll need to add Jupytext metadata to your
+MyST Notebooks. See [](myst-nb/sphinx) for more details.
 
 ## Parse extensions other than `.md` and `.ipynb`
 

--- a/docs/use/start.md
+++ b/docs/use/start.md
@@ -1,0 +1,29 @@
+# Get started
+
+This section covers how to get started with the `MyST-NB` Sphinx extension.
+The Sphinx extension allows you to read markdown (`.md`) and Jupyter Notebook (`.ipynb`)
+files into your Sphinx site. It also enables you to write [MyST Markdown](myst.md)
+in your pages.
+
+## Install and activate
+
+To install `myst-nb`, do the following:
+
+* **Install** `myst-nb` with the following command:
+
+  ```bash
+  pip install myst-nb
+  ```
+
+* **Activate** the `myst_nb` extension in your Sphinx site by adding it to your list of
+  Sphinx extensions in `conf.py`:
+
+  ```python
+  extensions = [
+      ...,
+      "myst_nb"
+  ]
+  ```
+
+Once you do this, MyST-NB will now parse both markdown (`.md`) and
+Jupyter notebooks (`.ipynb`) into your Sphinx site.


### PR DESCRIPTION
This is an attempt at clarifying a few things that were getting intermixed in our documentation, to try and resolve some conceptual issues that arose in #210 . It does the following:

* Creates a top-level page about MyST Markdown Notebooks, with links to other relevant documentation
* Adds more information about MyST Notebooks like the "spec" for a minimal MyST Notebook, with lots of cross-refs to other documentation for how to use MyST Notebooks in other tools
* Re-focuses the `Use and Configure` section to explicitly be about the Sphinx extension.
