### PR TITLE
🐛 FIX: Update of `nb-exec-table`s

### DIFF
--- a/myst_nb/exec_table.py
+++ b/myst_nb/exec_table.py
@@ -1,16 +1,53 @@
-"""A directive to create a table of executed notebooks, and related statistics."""
+"""A directive to create a table of executed notebooks, and related statistics.
+
+This directive utilises the
+``env.nb_execution_data`` and ``env.nb_execution_data_changed`` variables,
+set by myst-nb, to produce a table of statistics,
+which will be updated when any notebooks are modified/removed.
+"""
 from datetime import datetime
 
 from docutils import nodes
+from sphinx.transforms import SphinxTransform
 from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util.docutils import SphinxDirective
+from sphinx.util import logging
+
+LOGGER = logging.getLogger(__name__)
 
 
 def setup_exec_table(app):
     """execution statistics table."""
     app.add_node(ExecutionStatsNode)
     app.add_directive("nb-exec-table", ExecutionStatsTable)
+    app.add_transform(ExecutionStatsTransform)
     app.add_post_transform(ExecutionStatsPostTransform)
+    app.connect("builder-inited", add_doc_tracker)
+    app.connect("env-purge-doc", remove_doc)
+    app.connect("env-updated", update_exec_tables)
+
+
+def add_doc_tracker(app):
+    """This variable keeps track of want documents contain an `nb-exec-table` directive.
+    """
+    if not hasattr(app.env, "docs_with_exec_table"):
+        app.env.docs_with_exec_table = set()
+
+
+def remove_doc(app, env, docname):
+    env.docs_with_exec_table.discard(docname)
+
+
+def update_exec_tables(app, env):
+    """If the execution data has changed,
+    this callback adds the list of documents containing an `nb-exec-table` directive
+    to the list of document that are outdated.
+    """
+    if not (env.nb_execution_data_changed and env.docs_with_exec_table):
+        return None
+    if env.docs_with_exec_table:
+        LOGGER.info("Updating `nb-exec-table`s in: %s", env.docs_with_exec_table)
+    return list(env.docs_with_exec_table)
 
 
 class ExecutionStatsNode(nodes.General, nodes.Element):
@@ -28,8 +65,20 @@ class ExecutionStatsTable(SphinxDirective):
         return [ExecutionStatsNode()]
 
 
+class ExecutionStatsTransform(SphinxTransform):
+    """Updates the list of documents containing an `nb-exec-table` directive."""
+
+    default_priority = 400
+
+    def apply(self):
+        self.env.docs_with_exec_table.discard(self.env.docname)
+        for node in self.document.traverse(ExecutionStatsNode):
+            self.env.docs_with_exec_table.add(self.env.docname)
+            break
+
+
 class ExecutionStatsPostTransform(SphinxPostTransform):
-    """Replace the placeholder node with the final table."""
+    """Replace the placeholder node with the final table nodes."""
 
     default_priority = 400
 
@@ -83,10 +132,11 @@ def make_stat_table(nb_execution_data):
     tbody = nodes.tbody()
     tgroup += tbody
 
-    for doc, data in nb_execution_data.items():
+    for docname in sorted(nb_execution_data.keys()):
+        data = nb_execution_data[docname]
         row = nodes.row()
         tbody += row
-        row.append(nodes.entry("", nodes.paragraph(text=doc)))
+        row.append(nodes.entry("", nodes.paragraph(text=docname)))
         for name in key2header.keys():
             text = key2transform[name](data[name])
             row.append(nodes.entry("", nodes.paragraph(text=text)))

--- a/myst_nb/parser.py
+++ b/myst_nb/parser.py
@@ -215,9 +215,9 @@ class SphinxNBRenderer(SphinxRenderer):
             sphinx_cell += cell_input
 
             # Input block
-            code_block = nodes.literal_block(
-                text=cell["source"], language=token.meta["lexer"]
-            )
+            code_block = nodes.literal_block(text=cell["source"])
+            if token.meta.get("lexer", None) is not None:
+                code_block["language"] = token.meta["lexer"]
             cell_input += code_block
 
         # ==================

--- a/tests/nb_fixtures/basic.txt
+++ b/tests/nb_fixtures/basic.txt
@@ -28,7 +28,7 @@ cells:
     <docinfo>
     <CellNode cell_type="code" classes="cell">
         <CellInputNode classes="cell_input">
-            <literal_block language="True" xml:space="preserve">
+            <literal_block xml:space="preserve">
                 a=1
                 print(a)
 .
@@ -76,7 +76,7 @@ cells:
     <docinfo>
     <CellNode cell_type="code" classes="cell">
         <CellInputNode classes="cell_input">
-            <literal_block language="True" xml:space="preserve">
+            <literal_block xml:space="preserve">
                 a=1
                 print(a)
         <CellOutputNode classes="cell_output">
@@ -109,7 +109,7 @@ cells:
             A Title
         <CellNode cell_type="code" classes="cell">
             <CellInputNode classes="cell_input">
-                <literal_block language="True" xml:space="preserve">
+                <literal_block xml:space="preserve">
                     a=1
                     print(a)
         <paragraph>

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -15,6 +15,7 @@ def test_basic_unrun_auto(sphinx_run, file_regression, check_nbs):
     # Test execution statistics, should look like:
     # {'basic_unrun': {'mtime': '2020-08-20T03:32:27.061454', 'runtime': 0.964572671,
     #                  'method': 'auto', 'succeeded': True}}
+    assert sphinx_run.env.nb_execution_data_changed is True
     assert "basic_unrun" in sphinx_run.env.nb_execution_data
     assert sphinx_run.env.nb_execution_data["basic_unrun"]["method"] == "auto"
     assert sphinx_run.env.nb_execution_data["basic_unrun"]["succeeded"] is True
@@ -34,6 +35,7 @@ def test_basic_unrun_cache(sphinx_run, file_regression, check_nbs):
     # Test execution statistics, should look like:
     # {'basic_unrun': {'mtime': '2020-08-20T03:32:27.061454', 'runtime': 0.964572671,
     #                  'method': 'cache', 'succeeded': True}}
+    assert sphinx_run.env.nb_execution_data_changed is True
     assert "basic_unrun" in sphinx_run.env.nb_execution_data
     assert sphinx_run.env.nb_execution_data["basic_unrun"]["method"] == "cache"
     assert sphinx_run.env.nb_execution_data["basic_unrun"]["succeeded"] is True

--- a/tests/test_text_based.py
+++ b/tests/test_text_based.py
@@ -38,8 +38,7 @@ def test_basic_run_exec_off(sphinx_run, file_regression, check_nbs):
 
     file_regression.check(sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb")
     file_regression.check(
-        sphinx_run.get_doctree().pformat().replace('"True"', '"ipython3"'),
-        extension=".xml",
+        sphinx_run.get_doctree().pformat(), extension=".xml",
     )
 
 

--- a/tests/test_text_based/test_basic_run_exec_off.xml
+++ b/tests/test_text_based/test_basic_run_exec_off.xml
@@ -8,6 +8,6 @@
                 jupytext --to myst tests/notebooks/basic_unrun.ipynb
         <CellNode cell_type="code" classes="cell">
             <CellInputNode classes="cell_input">
-                <literal_block language="ipython3" xml:space="preserve">
+                <literal_block xml:space="preserve">
                     a=1
                     print(a)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py{36,37,38}-sphinx{2,3},docs
+envlist = py{36,37,38}-sphinx{2,3},docs-clean
 
 [testenv:py{36,37,38}-sphinx{2,3}]
 recreate = false
@@ -21,12 +21,12 @@ deps =
     sphinx3: sphinx>=3,<4
 commands = pytest {posargs}
 
-[testenv:docs]
+[testenv:docs-{update,clean}]
 recreate = false
 extras = rtd
 deps =
     ipython<=7.11.0  # required by coconut
 whitelist_externals = rm
 commands =
-    rm -rf docs/_build
-    sphinx-build -nW --keep-going -b html docs/ docs/_build/html
+    clean: rm -rf docs/_build
+    sphinx-build {posargs} -nW --keep-going -b html docs/ docs/_build/html


### PR DESCRIPTION
Also

- Use custom `SphinxError` for invalid configuration values
- fixed bug when code cell language of failed notebooks was being added as None
- Sort table rows by docname