### PR TITLE
🐛 FIX: remove cell background as none

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -7,7 +7,6 @@ div.container.cell {
 /* Removing all background formatting so we can control at the div level */
 .cell_input div.highlight, .cell_input pre, .cell_output .output * {
   border: none;
-  background: none;
   background-color: transparent;
   box-shadow: none;
 }


### PR DESCRIPTION
This suggestion fixes the issue with Jupyter Book that I raised last week, which was that the toolbars for Bokeh data visualizations are not showing up. Removing cell backgrounds as none allows them to show up correctly.
https://github.com/executablebooks/jupyter-book/issues/905