### PR TITLE
🐛 FIX: remove cell background-color CSS for cells

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -7,7 +7,6 @@ div.container.cell {
 /* Removing all background formatting so we can control at the div level */
 .cell_input div.highlight, .cell_input pre, .cell_output .output * {
   border: none;
-  background-color: transparent;
   box-shadow: none;
 }
 


### PR DESCRIPTION
This is related to my previous pull request #261 and previous Jupyter Book issue executablebooks/jupyter-book#905, which was that Bokeh plot toolbars were not showing up. My previous pull request fixed the toolbar issue, but I subsequently realized that Bokeh hover tooltips were showing up with transparent backgrounds, which is not how they should appear.

Removing the cell background-color entirely fixes the issue with Bokeh hover tooltips, and it doesn't seem like this fix is causing any other problems with the cells in my personal Jupyter Book.

## Issue 
Bokeh plot with cell background-color as `transparent`

![Screen Shot 2020-10-05 at 10 21 16 AM](https://user-images.githubusercontent.com/20325102/95091623-ada52400-06f4-11eb-93d6-607f8d3df4e5.png)

## Sugested Fix
Bokeh plot with cell background-color removed

![Screen Shot 2020-10-05 at 10 21 01 AM](https://user-images.githubusercontent.com/20325102/95091612-a8e07000-06f4-11eb-858b-5d2ca2a9e617.png)
