### PR TITLE
Return False if is_myst_notebook encounters empty file

### DIFF
--- a/myst_nb/converter.py
+++ b/myst_nb/converter.py
@@ -90,6 +90,9 @@ def is_myst_notebook(line_iter: Iterable[str]) -> bool:
             break
         yaml_lines.append(line.rstrip() + "\n")
 
+    if not yaml_lines:
+        return False
+
     try:
         front_matter = yaml.safe_load("".join(yaml_lines))
     except Exception:


### PR DESCRIPTION
This was ultimately "user error", but I'm using `jupyter-book` and had an empty markdown file in my folder (I also had `only_build_toc_files: true` so I assumed it wouldn't be an issue)... but I got an error with a traceback ending in

```pytb
  File ".../site-packages/myst_nb/converter.py", line 100, in is_myst_notebook
    front_matter.get("jupytext", {})
AttributeError: 'NoneType' object has no attribute 'get'
```

<details>

```pytb
Traceback (most recent call last):
  File ".../site-packages/jupyter_book/sphinx.py", line 141, in build_sphinx
    app.build(force_all, filenames)
  File ".../site-packages/sphinx/application.py", line 352, in build
    self.builder.build_update()
  File ".../site-packages/sphinx/builders/__init__.py", line 297, in build_update
    self.build(to_build,
  File ".../site-packages/sphinx/builders/__init__.py", line 311, in build
    updated_docnames = set(self.read())
  File ".../site-packages/sphinx/builders/__init__.py", line 418, in read
    self._read_serial(docnames)
  File ".../site-packages/sphinx/builders/__init__.py", line 439, in _read_serial
    self.read_doc(docname)
  File ".../site-packages/sphinx/builders/__init__.py", line 479, in read_doc
    doctree = read_doc(self.app, self.env, self.env.doc2path(docname))
  File ".../site-packages/sphinx/io.py", line 223, in read_doc
    pub.publish()
  File ".../site-packages/docutils/core.py", line 217, in publish
    self.document = self.reader.read(self.source, self.parser,
  File ".../site-packages/sphinx/io.py", line 128, in read
    self.parse()
  File ".../site-packages/docutils/readers/__init__.py", line 77, in parse
    self.parser.parse(self.input, document)
  File ".../site-packages/myst_nb/parser.py", line 51, in parse
    converter = get_nb_converter(
  File ".../site-packages/myst_nb/converter.py", line 66, in get_nb_converter
    if is_myst_notebook(source_iter):
  File ".../site-packages/myst_nb/converter.py", line 100, in is_myst_notebook
    front_matter.get("jupytext", {})
AttributeError: 'NoneType' object has no attribute 'get'
```

</details>

Bailing on `is_myst_notebook` if `yaml_lines` is empty allowed my book to be built with an empty markdown file.  curious if you'd consider this PR.

couldn't quickly identify where the best place to add a test would be.  but happy to do so if you direct me