### PR TITLE
🚀 RELEASE: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 0.12.0 - 2021-02-23
+
+This release adds an experimental MyST-NB feature to enable loading of code from a file
+for `code-cell` directives using a `:load: <file>` option.
+
+Usage information is available in the [docs](https://myst-nb.readthedocs.io/en/latest/use/markdown.html#syntax-for-code-cells)
+
 ## 0.11.1 - 2021-01-20
 
 Minor update to handle MyST-Parser `v0.13.3` and `v4.5` notebooks.

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 from collections.abc import Sequence
 import os


### PR DESCRIPTION
This release adds an experimental MyST-NB feature to enable loading of code from a file
for `code-cell` directives using a `:load: <file>` option.

Usage information is available in the [docs](https://myst-nb.readthedocs.io/en/latest/use/markdown.html#syntax-for-code-cells)
