### PR TITLE
Demonstrating markdown jupytext bug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,10 @@ html_static_path = ["_static"]
 
 copybutton_selector = "div:not(.output) > div.highlight pre"
 
-nb_custom_formats = {".Rmd": ["jupytext.reads", {"fmt": "Rmd"}]}
+nb_custom_formats = {
+    ".Rmd": ["jupytext.reads", {"fmt": "Rmd"}],
+    ".md": ["jupytext.reads", {"fmt": "markdown"}],
+}
 jupyter_execute_notebooks = "cache"
 execution_show_tb = "READTHEDOCS" in os.environ
 execution_timeout = 60  # Note: 30 was timing out on RTD

--- a/docs/examples/custom-formats.Rmd
+++ b/docs/examples/custom-formats.Rmd
@@ -26,7 +26,7 @@ If the function takes additional keyword arguments, then you can specify these a
 For example this is what the default conversion would look like:
 
 ```python
-nbsphinx_custom_formats = {
+nb_custom_formats = {
     '.ipynb': ['nbformat.reads', {'as_version': 4}],
 }
 ```


### PR DESCRIPTION
In https://github.com/executablebooks/meta/discussions/272#discussioncomment-415176 @parmentelat noted that it wasn't possible to use non-MyST markdown notebooks from Jupytext, because it raises this error:

```
Extension error:
source_suffix '.md' is already registered
```

This PR shows the necessary change to cause this error to pop up.