### PR TITLE
FIX: Update priority for native LaTeX output for html and latex builders

### DIFF
--- a/myst_nb/render_outputs.py
+++ b/myst_nb/render_outputs.py
@@ -35,11 +35,11 @@ def get_default_render_priority(builder: str) -> Optional[List[str]]:
             WIDGET_VIEW_MIMETYPE,
             "application/javascript",
             "text/html",
+            "text/latex",
             "image/svg+xml",
             "image/png",
             "image/jpeg",
             "text/markdown",
-            "text/latex",
             "text/plain",
         )
         for builder in (
@@ -56,10 +56,10 @@ def get_default_render_priority(builder: str) -> Optional[List[str]]:
     }
     # TODO: add support for "image/svg+xml"
     priority["latex"] = (
+        "text/latex",
         "application/pdf",
         "image/png",
         "image/jpeg",
-        "text/latex",
         "text/markdown",
         "text/plain",
     )


### PR DESCRIPTION
This PR increases the priority for `text/latex` representations for `html` and `latex` builders.

For `html` -- mathjax renders the `text/latex` representation more cleanly than typical images provided by some underlying packages (i.e. `png` images)

For `latex` -- native latex syntax should be used in preference. 