### PR TITLE
⬆️ UPDATE: jupyter_sphinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "myst-parser>=0.13.5",
         "docutils>=0.15",
         "sphinx>=2,<4",
-        "jupyter_sphinx>=0.3.2",
+        "jupyter_sphinx~=0.3.2",
         "jupyter-cache~=0.4.1",
         "ipython",
         "nbformat~=5.0",

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,10 @@ setup(
     python_requires=">=3.6",
     package_data={"myst_nb": ["_static/*"]},
     install_requires=[
-        "myst-parser~=0.13.3",
+        "myst-parser>=0.13.5",
         "docutils>=0.15",
         "sphinx>=2,<4",
-        # TODO 0.3.2 requires some changes to the pytests
-        "jupyter_sphinx==0.3.1",
+        "jupyter_sphinx>=0.3.2",
         "jupyter-cache~=0.4.1",
         "ipython",
         "nbformat~=5.0",
@@ -70,7 +69,8 @@ setup(
             "pytest-cov~=2.8",
             "coverage<5.0",
             "pytest-regressions",
-            "matplotlib",
+            # TODO: 3.4.0 has some warnings that need to be fixed in the tests.
+            "matplotlib~=3.3.0",
             "numpy",
             "sympy",
             "pandas",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     python_requires=">=3.6",
     package_data={"myst_nb": ["_static/*"]},
     install_requires=[
-        "myst-parser>=0.13.5",
+        "myst-parser~=0.13.5",
         "docutils>=0.15",
         "sphinx>=2,<4",
         "jupyter_sphinx~=0.3.2",

--- a/tests/test_text_based.py
+++ b/tests/test_text_based.py
@@ -36,7 +36,6 @@ def test_basic_run(sphinx_run, file_regression, check_nbs):
 def test_basic_run_exec_off(sphinx_run, file_regression, check_nbs):
     sphinx_run.build()
     # print(sphinx_run.status())
-    assert "Notebook code has no file extension metadata" in sphinx_run.warnings()
     assert "language_info" not in set(sphinx_run.app.env.metadata["basic_unrun"].keys())
     assert sphinx_run.app.env.metadata["basic_unrun"]["author"] == "Chris"
 


### PR DESCRIPTION
Also pinned a few other package versions required for tests to pass.

I want this because `jupyter_sphinx 0.13.2` gets rid of the `"Notebook code has no file extension metadata"` warning that occasionally breaks my builds, and the pip dependency resolver complains if I try to install 0.13.2 with myst-nb.

I know how to work around that warning by adding appropriate metadata to the notebooks, but it's annoying to have to do that for every new notebook, and it's extra boilerplate that shouldn't be necessary.