### PR TITLE
👌 IMPROVE: Fix test warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         sphinx: [">=3,<4"]
         include:
           - os: ubuntu-latest
@@ -76,10 +76,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Build package
         run: |
           pip install wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ project_urls =
 packages = find:
 install_requires =
     docutils>=0.15
-    importlib_metadata
+    importlib_metadata>=3.6; python_version < "3.10"
     ipython
     ipywidgets>=7.0.0,<8
     jupyter-cache~=0.4.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,14 @@ def get_test_path():
     return _get_test_path
 
 
+def read_text(path):
+    try:
+        return path.read_text()
+    except AttributeError:
+        # sphinx 2 compat
+        return path.text()
+
+
 class SphinxFixture:
     """A class returned by the ``sphinx_run`` fixture, to run sphinx,
     and retrieve aspects of the build.
@@ -97,7 +105,7 @@ class SphinxFixture:
         _path = self.app.outdir / (name + ".html")
         if not _path.exists():
             pytest.fail("html not output")
-        return _path.text()
+        return read_text(_path)
 
     def get_nb(self, index=0):
         """Return the output notebook (after any execution)."""
@@ -105,7 +113,7 @@ class SphinxFixture:
         _path = self.app.srcdir / "_build" / "jupyter_execute" / (name + ".ipynb")
         if not _path.exists():
             pytest.fail("notebook not output")
-        return _path.text()
+        return read_text(_path)
 
     def get_report_file(self, index=0):
         """Return the report file for a failed execution."""
@@ -113,7 +121,7 @@ class SphinxFixture:
         _path = self.app.outdir / "reports" / (name + ".log")
         if not _path.exists():
             pytest.fail("report log not output")
-        return _path.text()
+        return read_text(_path)
 
 
 @pytest.fixture()

--- a/tests/test_render_outputs.py
+++ b/tests/test_render_outputs.py
@@ -7,13 +7,13 @@ from myst_nb.render_outputs import MystNbEntryPointError, load_renderer
 
 
 def test_load_renderer_not_found():
-    with pytest.raises(MystNbEntryPointError):
+    with pytest.raises(MystNbEntryPointError, match="No Entry Point found"):
         load_renderer("other")
 
 
 @patch.object(EntryPoint, "load", lambda self: EntryPoint)
 def test_load_renderer_not_subclass():
-    with pytest.raises(MystNbEntryPointError):
+    with pytest.raises(MystNbEntryPointError, match="Entry Point .* not a subclass"):
         load_renderer("default")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,7 @@
 [tox]
 envlist = py37-sphinx3
 
-[testenv]
-# only recreate the environment when we use `tox -r`
-recreate = false
-
-[testenv:py{36,37,38}-sphinx{2,3}]
+[testenv:py{36,37,38,39}-sphinx{2,3}]
 extras = testing
 deps =
     sphinx2: sphinx>=2,<3


### PR DESCRIPTION
- Use new entry point loading interface.
- `sphinx.testing.path.Path.text()` -> `sphinx.testing.path.Path.read_text()`
- Add python 3.9 to test matrix