### PR TITLE
👌 IMPROVE: Support old entry points interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status][codecov-badge]][codecov-link]
 [![Documentation Status][rtd-badge]][rtd-link]
 [![PyPI][pypi-badge]][pypi-link]
+[![Conda Version][conda-badge]][conda-link]
 
 A collection of tools for working with Jupyter Notebooks in Sphinx.
 
@@ -26,3 +27,5 @@ See the [Contributing Guide](https://myst-nb.readthedocs.io/en/latest/develop/co
 [codecov-link]: https://codecov.io/gh/executablebooks/MyST-NB
 [pypi-badge]: https://img.shields.io/pypi/v/myst-nb.svg
 [pypi-link]: https://pypi.org/project/myst-nb
+[conda-badge]: https://img.shields.io/conda/vn/conda-forge/myst-nb.svg
+[conda-link]: https://anaconda.org/conda-forge/myst-nb

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ project_urls =
 packages = find:
 install_requires =
     docutils>=0.15
-    importlib_metadata>=3.6
+    importlib_metadata
     ipython
     ipywidgets>=7.0.0,<8
     jupyter-cache~=0.4.1


### PR DESCRIPTION
Despite pinning to `importlib-metdata>=3.6` in #319,
https://github.com/python/importlib_metadata/issues/308
could still cause Conda installs to fail using the new entry points interface.
So now the pinning is removed, and the new interface is only used if available.