### PR TITLE
⬆️ UPGRADE: nbconvert 6 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     jupyter-cache~=0.4.1
     jupyter_sphinx~=0.3.2
     myst-parser~=0.14.0
-    nbconvert~=5.6
+    nbconvert>=5.6,<7
     nbformat~=5.0
     pyyaml
     sphinx>=2,<4


### PR DESCRIPTION
- fixes #325 
  - with the least work possible
  - could expand test matrix to test vs `5.x` and `6.x`