### PR TITLE
Allows more complex suffixes in notebooks

### DIFF
--- a/myst_nb/execution.py
+++ b/myst_nb/execution.py
@@ -10,6 +10,7 @@ The primary methods in this module are:
 
 """
 import os
+import re
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -225,8 +226,11 @@ def is_valid_exec_file(env: BuildEnvironment, docname: str) -> bool:
     doc_path = env.doc2path(docname)
     if doc_path in env.nb_excluded_exec_paths:
         return False
-    extension = os.path.splitext(doc_path)[1]
-    if extension not in env.nb_allowed_exec_suffixes:
+    matches = tuple(
+        re.search(re.escape(suffix) + "$", doc_path)
+        for suffix in env.nb_allowed_exec_suffixes
+    )
+    if not any(matches):
         return False
     return True
 

--- a/myst_nb/execution.py
+++ b/myst_nb/execution.py
@@ -14,7 +14,7 @@ import re
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Set
 
 import nbformat as nbf
 from jupyter_cache import get_cache
@@ -328,7 +328,7 @@ def execute_staged_nb(
 
 
 def nb_has_all_output(
-    source_path: str, nb_extensions: Tuple[str] = (".ipynb",)
+    source_path: str, nb_extensions: Iterable[str] = (".ipynb",)
 ) -> bool:
     """Determine if the path contains a notebook with at least one output."""
     has_outputs = False

--- a/myst_nb/execution.py
+++ b/myst_nb/execution.py
@@ -14,7 +14,7 @@ import re
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 import nbformat as nbf
 from jupyter_cache import get_cache
@@ -327,7 +327,9 @@ def execute_staged_nb(
     return result
 
 
-def nb_has_all_output(source_path: str, nb_extensions: List[str] = (".ipynb",)) -> bool:
+def nb_has_all_output(
+    source_path: str, nb_extensions: Tuple[str] = (".ipynb",)
+) -> bool:
     """Determine if the path contains a notebook with at least one output."""
     has_outputs = False
     ext = os.path.splitext(source_path)[1]


### PR DESCRIPTION
fixes #327 

Allows more complex suffixes in `env.nb_allowed_exec_suffixes`