### PR TITLE
[code load] Enable utf-8 as the standard encoding for reading code from files

### DIFF
--- a/myst_nb/converter.py
+++ b/myst_nb/converter.py
@@ -187,7 +187,7 @@ def read_cell_metadata(token, cell_index):
     return metadata
 
 
-def load_code_from_file(nb_path, file_name, token, body_lines):
+def load_code_from_file(nb_path, file_name, token, body_lines, encoding="utf-8"):
     """load source code from a file."""
     if nb_path is None:
         raise LoadFileParsingError("path to notebook not supplied for :load:")
@@ -200,7 +200,7 @@ def load_code_from_file(nb_path, file_name, token, body_lines):
         )
         LOGGER.warning(msg)
     try:
-        body_lines = file_path.read_text().split("\n")
+        body_lines = file_path.read_text(encoding=encoding).split("\n")
     except Exception:
         raise LoadFileParsingError("Can't read file from :load: {}".format(file_path))
     return body_lines


### PR DESCRIPTION
It looks like `windows` platform doesn't by default always use `utf-8` when reading text from files. I think this is a sensible cross-platform default. 

https://github.com/QuantEcon/lecture-python.myst/issues/144

There is also a [related issue reported on stackoverflow](https://stackoverflow.com/questions/49428723/unexpected-results-from-path-read-text-of-pathlib-when-reading-utf-8-encoded-f)