### PR TITLE
Allow Bokeh plots to be glued and pasted

### DIFF
--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -168,6 +168,24 @@ def setup(app: Sphinx):
     app.add_css_file("mystnb.css")
     app.add_domain(NbGlueDomain)
 
+    # Load bokeh
+    def install_bokeh(
+        app: Sphinx, pagename: str, templatename: str, context: "Dict", event_arg: "Any"
+    ) -> None:
+        if app.builder.format != "html":
+            return
+
+        domain = cast(NbGlueDomain, app.env.get_domain("glue"))
+        if domain.has_bokeh(pagename):
+            from bokeh.resources import CDN
+
+            for js_file in CDN.js_files:
+                app.add_js_file(js_file)
+            for js_raw in CDN.js_raw:
+                app.add_js_file(None, body=js_raw, type="text/javascript")  # type: ignore
+
+    app.connect("html-page-context", install_bokeh)
+
     # execution statistics table
     setup_exec_table(app)
 

--- a/myst_nb/nodes.py
+++ b/myst_nb/nodes.py
@@ -51,6 +51,20 @@ class CellOutputBundleNode(nodes.container):
         """The cell level metadata for this output."""
         return self._renderer
 
+    @property
+    def has_bokeh(self) -> bool:
+        """Whether or not Bokeh JSON is in the output."""
+        for output in self.outputs:
+            mime_prefix = (
+                output.get("metadata", {}).get("scrapbook", {}).get("mime_prefix")
+            )
+            if mime_prefix is None:
+                return False
+            for k in output.get("data", {}).keys():
+                if k.replace(mime_prefix, "") == "application/jupyter-book-bokeh-json":
+                    return True
+        return False
+
     def copy(self):
         obj = self.__class__(
             outputs=self._outputs,


### PR DESCRIPTION
Using the JSON-type output from Bokeh, this creates appropriate HTML and
Javascript nodes in the output when the Bokeh+JSON mimetype is found.
The Python Bokeh library is only imported when it is needed, to avoid a
package dependency on Bokeh. Users will need to install Bokeh via pip or
conda to be able to glue/paste Bokeh plots. Using the JSON output allows
plots to be pasted into figures as well as a general element with no
further changes.

Uses the Sphinx configuration to decide whether a page has Bokeh content
and only loads BokehJS on those pages. This simplifies the script that
needs to be embedded in each paste and ensures that Bokeh is only loaded
once from the CDN, unless the user runs output_notebook(). In the case
where the user runs output_notebook() the BokehJS library is loaded
twice but this doesn't appear to cause any problems.