### PR TITLE
🔧 MAINT: Make a more specific selector for no-border

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -5,7 +5,7 @@ div.container.cell {
 }
 
 /* Removing all background formatting so we can control at the div level */
-.cell_input div.highlight, .cell_input pre, .cell_output .output * {
+.cell_input div.highlight, .cell_input pre, .cell_output pre, .cell_output .output {
   border: none;
   box-shadow: none;
 }

--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -5,7 +5,7 @@ div.container.cell {
 }
 
 /* Removing all background formatting so we can control at the div level */
-.cell_input div.highlight, .cell_input pre, .cell_output pre, .cell_output .output {
+.cell_input div.highlight, .cell_output pre, .cell_input pre, .cell_output .output {
   border: none;
   box-shadow: none;
 }


### PR DESCRIPTION
closes #287 

The original problem was that wildcard CSS leaks, and it's hard to override. Unfortunately, it isn't completely clear to me what the wildcard was supposed to catch in the first place (the description in the source was vague and #287 lacked this info). To figure it out I removed the wildcard and compared the outputs, taking the jupyterbook repo. The proposed change seems to fix the problem with preformatted outputs.

Without wildcard:

![image](https://user-images.githubusercontent.com/2069677/128440765-13334110-f8c4-4e13-86c4-2aa1ff05533b.png)

![image](https://user-images.githubusercontent.com/2069677/128440788-db766cb9-e14d-4430-8223-eb87b8c55fdb.png)

With the proposed change:

![image](https://user-images.githubusercontent.com/2069677/128440846-b06065c8-5296-4723-9bc1-be2ee448bdf9.png)

![image](https://user-images.githubusercontent.com/2069677/128440870-9b4bcae3-8497-4a1d-8640-46087eddbf03.png)

Identical to the original, as far as I can tell. If I overlooked other problems, do let me know.