### PR TITLE
🔧 MAINT: Pin ipykernel to ~v5.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ intersphinx_mapping = {
     "markdown_it": ("https://markdown-it-py.readthedocs.io/en/latest", None),
     "nbclient": ("https://nbclient.readthedocs.io/en/latest", None),
     "nbformat": ("https://nbformat.readthedocs.io/en/latest", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/3.x", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 intersphinx_cache_limit = 5

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ testing =
     pytest-cov~=2.8
     pytest-regressions
     sympy
+    ipykernel~=5.5
 
 [flake8]
 max-line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ rtd =
     altair
     bokeh
     coconut~=1.4.3
+    ipykernel~=5.5
     ipywidgets
     jupytext~=1.11.2
     matplotlib
@@ -86,6 +87,7 @@ rtd =
     sympy
 testing =
     coverage<5.0
+    ipykernel~=5.5
     jupytext~=1.11.2
     # TODO: 3.4.0 has some warnings that need to be fixed in the tests.
     matplotlib~=3.3.0
@@ -95,7 +97,6 @@ testing =
     pytest-cov~=2.8
     pytest-regressions
     sympy
-    ipykernel~=5.5
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
closes #346 