### PR TITLE
🐛 FIX: Image URI issue for latex build when source has subdirectories

### DIFF
--- a/myst_nb/render_outputs.py
+++ b/myst_nb/render_outputs.py
@@ -472,8 +472,7 @@ class CellOutputRenderer(CellOutputRendererBase):
             filename = os.path.basename(output.metadata["filenames"][mime_type])
             # checks if file dir path is inside a subdir of dir
             filedir = os.path.dirname(output.metadata["filenames"][mime_type])
-            print(self.sphinx_dir, "--", filedir)
-            outbasedir = os.path.basename(self.sphinx_dir)
+            outbasedir = os.path.abspath(self.sphinx_dir)
             subpaths = filedir.split(outbasedir)
             final_dir = self.sphinx_dir
             if subpaths and len(subpaths) > 1:


### PR DESCRIPTION
fixes https://github.com/executablebooks/MyST-NB/issues/367 

This PR has one possible fix, splitting with `abspath` pf sphinx_dir to avoid `../`s 
The corresponding issue dives more into the bug details. 