### PR TITLE
🚀 RELEASE: updates for release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## 0.13.2 - 2022-01-31
 
-🐛 FIX: Image URI issue for latex build when source has subdirectories
+This release has a few improvements and fixes:
+
+- 🧪 TESTS: Pin ipython<8
+- 👌 IMPROVE: Add CSS support for 8-bit ANSI colours
+- 👌 IMPROVE: Use configured nb_render_plugin for glue nodes
+- 🐛 FIX: Image URI issue for latex build when source has subdirectories
 
 ## 0.13.1 - 2021-10-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.13.2 - 2021-10-25
+
+🐛 FIX: Image URI issue for latex build when source has subdirectories
+
 ## 0.13.1 - 2021-10-04
 
 ✨ NEW: `nb_merge_streams` configuration  [[PR #364](https://github.com/executablebooks/MyST-NB/pull/364)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.13.2 - 2021-10-25
+## 0.13.2 - 2022-01-31
 
 🐛 FIX: Image URI issue for latex build when source has subdirectories
 

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 
 import os
 from collections.abc import Sequence


### PR DESCRIPTION
This sets up the release for `0.13.2`