### PR TITLE
[ENH] Add initial svg handling

### DIFF
--- a/myst_nb/render_outputs.py
+++ b/myst_nb/render_outputs.py
@@ -52,9 +52,9 @@ def get_default_render_priority(builder: str) -> Optional[List[str]]:
             "epub",
         )
     }
-    # TODO: add support for "image/svg+xml"
     priority["latex"] = (
         "application/pdf",
+        "image/svg+xml",
         "image/png",
         "image/jpeg",
         "text/latex",


### PR DESCRIPTION
Removes a TODO
Adds a supported mime type for latex

This currently creates a svg-file from the inline svg component, which can be handled by other tools later

This basically fixes #370 as their the svg is now not handled as an text type anymore