### PR TITLE
🧪 TESTS: Pin ipython<8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,8 @@ rtd =
 testing =
     coverage<5.0
     ipykernel~=5.5
+    # ipython v8 is only available for Python 3.8+, and it changes exception text
+    ipython<8
     jupytext~=1.11.2
     # TODO: 3.4.0 has some warnings that need to be fixed in the tests.
     matplotlib~=3.3.0


### PR DESCRIPTION
ipython v8 is only available for Python 3.8+, and it changes exception text, which fails some regression tests