### PR TITLE
🐛 FIX: Version pinning to execute tests on all supported python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ rtd =
     jupytext~=1.11.2
     matplotlib
     numpy
-    pandas~=1.3.5
+    pandas~=1.1.5
     plotly
     sphinx-book-theme~=0.1.0
     sphinx-copybutton
@@ -94,7 +94,7 @@ testing =
     # TODO: 3.4.0 has some warnings that need to be fixed in the tests.
     matplotlib~=3.3.0
     numpy
-    pandas~=1.3.5
+    pandas~=1.1.5
     pytest~=5.4
     pytest-cov~=2.8
     pytest-regressions

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ rtd =
     jupytext~=1.11.2
     matplotlib
     numpy
-    pandas
+    pandas~=1.3.5
     plotly
     sphinx-book-theme~=0.1.0
     sphinx-copybutton
@@ -94,7 +94,7 @@ testing =
     # TODO: 3.4.0 has some warnings that need to be fixed in the tests.
     matplotlib~=3.3.0
     numpy
-    pandas
+    pandas~=1.3.5
     pytest~=5.4
     pytest-cov~=2.8
     pytest-regressions


### PR DESCRIPTION
Since Python 3.6 requires pandas 1.1.x version, and we are supporting Python 3.6 here, so pinning that version.