### PR TITLE
UPGRADE: sphinx-togglebutton v0.3.0

### DIFF
--- a/docs/use/hiding.md
+++ b/docs/use/hiding.md
@@ -78,7 +78,8 @@ points =ax.scatter(*data, c=data[0], s=data[0])
 ## Hiding markdown cells
 
 You cannot hide an entire markdown cell, but you can sections of markdown **content** by using roles and directives.
-For more information on how to do this, see [the `sphinx-togglebutton` documentation](https://sphinx-togglebutton.readthedocs.io/en/latest/).
+
+For information on how to hide / toggle markdown content in Sphinx, see either [the `sphinx-togglebutton` documentation](https://sphinx-togglebutton.readthedocs.io/en/latest/) or the [`sphinx-design` dropdowns documentation](https://sphinx-design.readthedocs.io/en/latest/dropdowns.html).
 
 (use/removing)=
 

--- a/docs/use/hiding.md
+++ b/docs/use/hiding.md
@@ -77,58 +77,8 @@ points =ax.scatter(*data, c=data[0], s=data[0])
 
 ## Hiding markdown cells
 
-There are two ways to hide markdown cells. First, **you can add the `hide-input`**
-cell metadata. This triggers the same hiding behavior described above for
-code cells.
-
-+++ {"tags": ["hide-input"]}
-
-```{note}
-This cell was hidden by adding a `hide-input` tag to it!
-```
-
-+++
-
-You may also **use a Sphinx directive** to hide specific markdown content. This
-is possible by adding the **`.toggle`** class to any block-level directive
-that will allow for classes. For example, to the `container`, `note`, or `admonition`
-directives.
-
-For example, the hidden block below
-
-```{admonition} This cell was hidden with the toggle class
-:class: toggle
-Wow, a hidden block! ✨✨
-```
-
-Is generated with the following code:
-
-````
-```{admonition} This cell was hidden with the toggle class
-:class: toggle
-Wow, a hidden block! ✨✨
-```
-````
-
-
-`````{admonition} Don't add headings to toggle-able sections
-
-Note that containers for markdown (like notes, or this `container`
-directive) cannot have their own headings (ie, lines that start
-with `#`. If you'd like to use headings, do one of the following:
-
-* Use **bolded text** if you want to highlight sections of a
-  toggle-able section.
-* Use an **admonition** directive to control the title of the
-  message box (that's what this message box uses). Like so:
-  ````
-  ```{admonition} my admonition title
-  My admonition content
-  ```
-  ````
-`````
-
-+++
+You cannot hide an entire markdown cell, but you can sections of markdown **content** by using roles and directives.
+For more information on how to do this, see [the `sphinx-togglebutton` documentation](https://sphinx-togglebutton.readthedocs.io/en/latest/).
 
 (use/removing)=
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     nbformat~=5.0
     pyyaml
     sphinx>=3.1,<5
-    sphinx-togglebutton~=0.2.2
+    sphinx-togglebutton~=0.3.0
 python_requires = >=3.6
 include_package_data = True
 zip_safe = True


### PR DESCRIPTION
This PR does 2 things:

- Raises the pin on `sphinx-togglebutton` to ~= 0.3.0, so that we get the new UI elements that it introduced
- Removes some of the specific instructions in our "hide markdown content" section, because (I believe) we deprecated the ability to hide markdown cells with a cell tag, and so that content was out-of-date. This section now links out to the sphinx-togglebutton and sphinx-design docs, since myst-nb isn't directly responsible for hiding regular ol' content blocks.