### PR TITLE
WIP, ENH: Add alt option to glue figure

### DIFF
--- a/docs/use/glue.md
+++ b/docs/use/glue.md
@@ -232,12 +232,13 @@ For example, the following: ``My rounded mean: {glue:text}`boot_mean:.2f` `` wil
 ### The `glue:figure` directive
 
 With `glue:figure` you can apply more formatting to figure like objects,
-such as giving them a caption and referencable label:
+such as giving them a caption, referencable label, and alt text:
 
 ````md
 ```{glue:figure} boot_fig
 :figwidth: 300px
 :name: "fig-boot"
+:alt: "A histogram of the bootstrapped samples."
 
 This is a **caption**, with an embedded `{glue:text}` element: {glue:text}`boot_mean:.2f`!
 ```
@@ -246,6 +247,7 @@ This is a **caption**, with an embedded `{glue:text}` element: {glue:text}`boot_
 ```{glue:figure} boot_fig
 :figwidth: 300px
 :name: "fig-boot"
+:alt: "A histogram of the bootstrapped samples."
 
 This is a **caption**, with an embedded `{glue:text}` element: {glue:text}`boot_mean:.2f`!
 ```

--- a/myst_nb/nb_glue/domain.py
+++ b/myst_nb/nb_glue/domain.py
@@ -170,12 +170,14 @@ class PasteFigure(Paste):
     option_spec["figclass"] = directives.class_option
     option_spec["align"] = align
     option_spec["name"] = directives.unchanged
+    option_spec["alt"] = directives.unchanged
     has_content = True
 
     def run(self):
         figwidth = self.options.pop("figwidth", None)
         figclasses = self.options.pop("figclass", None)
         align = self.options.pop("align", None)
+        alt = self.options.pop("alt", None)
         # On the Paste node we should add an attribute to specify that only image
         # type mimedata is allowed, then this would be used by
         # PasteNodesToDocutils -> CellOutputsToNodes to alter the render priority
@@ -192,6 +194,8 @@ class PasteFigure(Paste):
             figure_node["classes"] += figclasses
         if align:
             figure_node["align"] = align
+        if alt:
+            figure_node["alt"] = alt
         self.add_name(figure_node)
         # note: this is copied directly from sphinx.Figure
         if self.content:

--- a/tests/notebooks/with_glue.ipynb
+++ b/tests/notebooks/with_glue.ipynb
@@ -207,6 +207,7 @@
     "\n",
     "```{glue:figure} key_plt\n",
     ":name: abc\n",
+    ":alt: alt-text for glued figure\n",
     "\n",
     "A caption....\n",
     "```",

--- a/tests/test_glue/test_parser.sphinx3.xml
+++ b/tests/test_glue/test_parser.sphinx3.xml
@@ -139,7 +139,7 @@
                 <inline classes="pasted-text">
                     undisplayed
                  inline…
-            <figure align="default" ids="abc" names="abc">
+            <figure align="default" ids="abc" names="abc" alt="alt-text for glued figure">
                 <CellOutputNode classes="cell_output">
                     <image candidates="{'*': '_build/jupyter_execute/with_glue_5_0.png'}" uri="_build/jupyter_execute/with_glue_5_0.png">
                 <caption>

--- a/tests/test_glue/test_parser.sphinx4.xml
+++ b/tests/test_glue/test_parser.sphinx4.xml
@@ -139,7 +139,7 @@
                 <inline classes="pasted-text">
                     undisplayed
                  inline…
-            <figure ids="abc" names="abc">
+            <figure alt="alt-text for glued figure" ids="abc" names="abc">
                 <CellOutputNode classes="cell_output">
                     <image candidates="{'*': '_build/jupyter_execute/with_glue_5_0.png'}" uri="_build/jupyter_execute/with_glue_5_0.png">
                 <caption>


### PR DESCRIPTION
Closes #211 

This tackles the first part of the problem, i.e. adding an `alt` optional argument to the `glue:figure` directive, but there's still work to be done to pass through the `alt` string to the final figure that is embedded in the output. I haven't had success tracing through the various abstractions/transforms that get from a `PasteNode` within the containing figure to the actual `image` node that ultimately gets rendered in the output. My sense is the best way to do this is to add a `PasteImageNode` (or similar) subclass that keeps the alt-text as an attribute, and modify the subsequent transforms etc. to ensure that the alt text is passed all the way through to the final `create_render_image` step. I'm not sure if this approach is consistent with the current design, so I figured I'd open a WIP PR hoping for someone more knowledgeable to weigh in.