### PR TITLE
👌 IMPROVE: Add image options to `glue:figure`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,10 +61,10 @@ jobs:
       # this is why we run `coverage xml` afterwards (required by codecov)
 
     - name: Upload to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7 && matrix.sphinx == '>=3,<4' && github.repository == 'executablebooks/MyST-NB'
+      if: github.repository == 'executablebooks/MyST-NB'
       uses: codecov/codecov-action@v1
       with:
-        name: myst-nb-pytests-py3.7
+        name: myst-nb-pytests
         flags: pytests
         file: ./coverage.xml
         fail_ci_if_error: true

--- a/docs/use/glue.md
+++ b/docs/use/glue.md
@@ -240,10 +240,24 @@ My rounded mean: {glue:text}`boot_mean:.2f` (95% CI: {glue:text}`boot_clo:.2f`/{
 ### The `glue:figure` directive
 
 With `glue:figure` you can apply more formatting to figure like objects,
-such as giving them a caption and referencable label:
+such as giving them a caption and referenceable label:
+
+:::{table} `glue:figure` directive options
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| alt | text | Alternate text of an image |
+| height | length | The desired height of an image |
+| width | length or percentage | The width of an image |
+| scale | percentage | The uniform scaling factor of an image |
+| class | text | A space-separated list of class names for the image |
+| figwidth | length or percentage | The width of the figure |
+| figclass | text | A space-separated list of class names for the figure |
+| name | text | referenceable label for the figure |
+:::
 
 ````md
 ```{glue:figure} boot_fig
+:alt: "Alternative title"
 :figwidth: 300px
 :name: "fig-boot"
 
@@ -252,6 +266,7 @@ This is a **caption**, with an embedded `{glue:text}` element: {glue:text}`boot_
 ````
 
 ```{glue:figure} boot_fig
+:alt: "Alternative title"
 :figwidth: 300px
 :name: "fig-boot"
 
@@ -291,7 +306,14 @@ A caption for a pandas table.
 The `glue:math` directive, is specific to latex math outputs
 (glued variables that contain a `text/latex` mimetype),
 and works similarly to the [sphinx math directive](https://www.sphinx-doc.org/en/1.8/usage/restructuredtext/directives.html#math).
-For example:
+
+:::{table} `glue:math` directive options
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| nowrap | flag | Prevent any wrapping of the given math in a math environment |
+| class | text | A space-separated list of class names |
+| label or name | text | referenceable label for the figure |
+:::
 
 ```{code-cell} ipython3
 import sympy as sym

--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -24,6 +24,7 @@ from myst_parser.main import MdParserConfig, create_md_parser
 from nbformat import NotebookNode
 from typing_extensions import Protocol
 
+from myst_nb.core.config import NbParserConfig
 from myst_nb.core.loggers import DEFAULT_LOG_TYPE, LoggerType
 
 if TYPE_CHECKING:
@@ -95,6 +96,11 @@ class NbElementRenderer:
         return self._renderer
 
     @property
+    def config(self) -> NbParserConfig:
+        """The notebook parser config"""
+        return self._renderer.nb_config
+
+    @property
     def logger(self) -> LoggerType:
         """The logger for this renderer.
 
@@ -126,7 +132,7 @@ class NbElementRenderer:
 
         :returns: URI to use for referencing the file
         """
-        output_folder = self.renderer.nb_config.output_folder
+        output_folder = self.config.output_folder
         filepath = Path(output_folder).joinpath(*path)
         if not output_folder:
             pass  # do not output anything if output_folder is not set (docutils only)
@@ -183,9 +189,7 @@ class NbElementRenderer:
                     "body": sanitize_script_content(json.dumps(ipywidgets_mime)),
                 },
             )
-            for i, (path, kwargs) in enumerate(
-                self.renderer.nb_config.ipywidgets_js.items()
-            ):
+            for i, (path, kwargs) in enumerate(self.config.ipywidgets_js.items()):
                 self.add_js_file(f"ipywidgets_{i}", path, kwargs)
 
         return metadata


### PR DESCRIPTION
`glue:figure` directive options:

| Option | Type | Description |
| ------ | ---- | ----------- |
| alt | text | Alternate text of an image |
| height | length | The desired height of an image |
| width | length or percentage | The width of an image |
| scale | percentage | The uniform scaling factor of an image |
| class | text | A space-separated list of class names for the image |
| figwidth | length or percentage | The width of the figure |
| figclass | text | A space-separated list of class names for the figure |
| name | text | referenceable label for the figure |