### PR TITLE
Feat: allow any value for expr

### DIFF
--- a/myst_nb/core/config.py
+++ b/myst_nb/core/config.py
@@ -188,6 +188,14 @@ class NbParserConfig:
             "sections": (Section.global_lvl, Section.execute),
         },
     )
+    eval_name_regex: str = dc.field(
+        default=r"^[a-zA-Z_][a-zA-Z0-9_]*$",
+        metadata={
+            "validator": instance_of(str),
+            "help": "Regex that matches permitted values of eval expressions",
+            "sections": (Section.global_lvl, Section.file_lvl, Section.execute),
+        },
+    )
     execution_mode: Literal["off", "force", "auto", "cache", "inline"] = dc.field(
         default="auto",
         metadata={

--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -39,9 +39,6 @@ class EvalNameError(Exception):
     """An exception for if an evaluation variable name is invalid."""
 
 
-EVAL_NAME_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-
-
 class NotebookClientBase:
     """A base client for interacting with Jupyter notebooks.
 

--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -34,6 +34,10 @@ class ExecutionError(Exception):
     """An exception for failed execution and `execution_raise_on_error` is true."""
 
 
+class EvalNameError(Exception):
+    """An exception for if an evaluation variable name is invalid."""
+
+
 class NotebookClientBase:
     """A base client for interacting with Jupyter notebooks.
 

--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import re
 from typing import Any
 
 from nbformat import NotebookNode
@@ -33,10 +32,6 @@ class ExecutionResult(TypedDict):
 
 class ExecutionError(Exception):
     """An exception for failed execution and `execution_raise_on_error` is true."""
-
-
-class EvalNameError(Exception):
-    """An exception for if an evaluation variable name is invalid."""
 
 
 class NotebookClientBase:

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -22,7 +22,7 @@ from nbformat import NotebookNode
 
 from myst_nb.ext.glue import extract_glue_data_cell
 
-from .base import ExecutionError, NotebookClientBase
+from .base import EvalNameError, ExecutionError, NotebookClientBase
 
 
 class NotebookClientInline(NotebookClientBase):
@@ -151,6 +151,8 @@ class NotebookClientInline(NotebookClientBase):
         return cell.get("execution_count", None), cell.get("outputs", [])
 
     def eval_variable(self, name: str) -> list[NotebookNode]:
+        if not re.match(self.nb_config.eval_name_regex, name):
+            raise EvalNameError(name)
         return self._client.eval_expression(name)
 
 

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -22,7 +22,7 @@ from nbformat import NotebookNode
 
 from myst_nb.ext.glue import extract_glue_data_cell
 
-from .base import EVAL_NAME_REGEX, EvalNameError, ExecutionError, NotebookClientBase
+from .base import ExecutionError, NotebookClientBase
 
 
 class NotebookClientInline(NotebookClientBase):

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+import re
 import shutil
 from tempfile import mkdtemp
 import time

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -151,8 +151,6 @@ class NotebookClientInline(NotebookClientBase):
         return cell.get("execution_count", None), cell.get("outputs", [])
 
     def eval_variable(self, name: str) -> list[NotebookNode]:
-        if not EVAL_NAME_REGEX.match(name):
-            raise EvalNameError(name)
         return self._client.eval_expression(name)
 
 

--- a/myst_nb/ext/eval/__init__.py
+++ b/myst_nb/ext/eval/__init__.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any
 from docutils import nodes
 from docutils.parsers.rst import directives as spec
 
-from myst_nb.core.execute.base import EvalNameError
 from myst_nb.core.render import NbElementRenderer
 from myst_nb.core.variables import (
     RetrievalError,
@@ -42,8 +41,6 @@ def retrieve_eval_data(document: nodes.document, key: str) -> list[VariableOutpu
         outputs = element.renderer.nb_client.eval_variable(key)
     except NotImplementedError:
         raise RetrievalError("This document does not have a running kernel")
-    except EvalNameError:
-        raise RetrievalError(f"The variable {key!r} is not a valid name")
     except Exception as exc:
         raise RetrievalError(f"variable evaluation error: {exc}")
     if not outputs:

--- a/myst_nb/ext/eval/__init__.py
+++ b/myst_nb/ext/eval/__init__.py
@@ -43,7 +43,9 @@ def retrieve_eval_data(document: nodes.document, key: str) -> list[VariableOutpu
     except NotImplementedError:
         raise RetrievalError("This document does not have a running kernel")
     except EvalNameError:
-        raise RetrievalError(f"The expression {key!r} is not valid according to the configured pattern")
+        raise RetrievalError(
+            f"The expression {key!r} is not valid according to the configured pattern"
+        )
     except Exception as exc:
         raise RetrievalError(f"variable evaluation error: {exc}")
     if not outputs:

--- a/myst_nb/ext/eval/__init__.py
+++ b/myst_nb/ext/eval/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from docutils import nodes
 from docutils.parsers.rst import directives as spec
 
+from myst_nb.core.execute.base import EvalNameError
 from myst_nb.core.render import NbElementRenderer
 from myst_nb.core.variables import (
     RetrievalError,
@@ -41,10 +42,12 @@ def retrieve_eval_data(document: nodes.document, key: str) -> list[VariableOutpu
         outputs = element.renderer.nb_client.eval_variable(key)
     except NotImplementedError:
         raise RetrievalError("This document does not have a running kernel")
+    except EvalNameError:
+        raise RetrievalError(f"The expression {key!r} is not valid according to the configured pattern")
     except Exception as exc:
         raise RetrievalError(f"variable evaluation error: {exc}")
     if not outputs:
-        raise RetrievalError(f"variable {key!r} does not return any outputs")
+        raise RetrievalError(f"expression {key!r} does not return any outputs")
 
     # the returned outputs could be one of the following:
     # https://nbformat.readthedocs.io/en/latest/format_description.html#code-cell-outputs


### PR DESCRIPTION
Currently, the `eval` role and directives *only* allow for C-like identifiers.

## Proposal in this PR

Remove the restriction on expression values in `eval` contexts.

## Advantages of this restriction (to be removed by this PR)

- Users are discouraged from writing unreadably complex code that breaks the narrative flow.
- Users are discouraged from writing code that can have side-effects (as there are far fewer rich-display hook implementations than there are user functions that modify globals).
  - Non-"pure" functions would lead to different results when executing the notebook in environments that do not support expression execution, e.g. `jupyter-cache` or `Jupyter Lab`[^myst-note].

## Disadvantages of this restriction (to be resolved by this PR)

- Every language has a different notion of "identifier". We're exclusively permitting C-like identifiers only. The current REGEX actually doesn't support certain valid Python identifiers that include unicode (e.g. [`℘` or `gänseblümchen`](https://tjol.eu/blog/unicode-identifiers.html). Whilst some of these might be a little far-fetched, I find myself regularly using `τ` for Mathematical expressions.
- Expressions have explanatory value. An identifier requires the author to jump to the definition of the identifier, which breaks the flow of reading the document source.
- Libraries without rich-display hooks that use display methods (e.g. `plot.display()` for `k3d`) need to use a capturing context object + re-reraise the MIME bundle (ugly)
- Expressions are more concise than assignments to name
   e.g. 
   ````markdown
   This is the sum {eval}`x.sum()`
   ````
   vs
   ````markdown
   ```{code-cell}
   x_sum = x.sum()
   ```
   This is the sum {eval}`x_sum`
   ````
- Other implementations of in-line expressions support this e.g. [RMarkdown](https://zsmith27.github.io/rmarkdown_crash-course/lesson-5-code-chunks-and-inline-code.html#inline-code)

Given that notebooks can *already* have side effects, I fairly strongly disagree with trying to fix this at the MyST level. I feel it's better for users to burn their own fingers than for us to impose restrictions upon them.

Maybe, if someone can find use for this kind of restriction, we can make it an opt-in configuration where the user can turn on REGEX matching, and specify the REGEX?

EDIT: Expounded pros and cons

[^myst-note]: jupyterlab-myst _does_ support inline expressions.