### PR TITLE
🐛 FIX: Inline exec variables with multiple outputs

### DIFF
--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -170,13 +170,13 @@ class NotebookClientBase:
         cell = cells[cell_index]
         return cell.get("execution_count", None), cell.get("outputs", [])
 
-    def eval_variable(self, name: str) -> NotebookNode | None:
+    def eval_variable(self, name: str) -> list[NotebookNode]:
         """Retrieve the value of a variable from the kernel.
 
         :param name: the name of the variable,
             must match the regex `[a-zA-Z][a-zA-Z0-9_]*`
 
-        :returns: a code cell output
+        :returns: code cell outputs
         :raises NotImplementedError: if the execution mode does not support this feature
         :raises EvalNameError: if the variable name is invalid
         """

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -150,14 +150,14 @@ class NotebookClientInline(NotebookClientBase):
         cell = cells[cell_index]
         return cell.get("execution_count", None), cell.get("outputs", [])
 
-    def eval_variable(self, name: str) -> NotebookNode | None:
+    def eval_variable(self, name: str) -> list[NotebookNode]:
         if not EVAL_NAME_REGEX.match(name):
             raise EvalNameError(name)
         return self._client.eval_expression(name)
 
 
 class ModifiedNotebookClient(NotebookClient):
-    async def async_eval_expression(self, name: str) -> NotebookNode | None:
+    async def async_eval_expression(self, name: str) -> list[NotebookNode]:
         """Evaluate an expression in the kernel.
 
         This is a modified version of `async_execute_cell`,
@@ -204,7 +204,6 @@ class ModifiedNotebookClient(NotebookClient):
                     task_poll_output_msg.cancel()
             finally:
                 raise
-
-        return cell.outputs[0] if cell.outputs else None
+        return cell.outputs
 
     eval_expression = run_sync(async_eval_expression)

--- a/myst_nb/docutils_.py
+++ b/myst_nb/docutils_.py
@@ -310,13 +310,15 @@ class DocutilsNbRenderer(DocutilsRenderer, MditRenderMixin):
                 try:
                     mime_type = next(x for x in mime_priority if x in output["data"])
                 except StopIteration:
-                    self.create_warning(
-                        "No output mime type found from render_priority",
-                        line=line,
-                        append_to=self.current_node,
-                        wtype=DEFAULT_LOG_TYPE,
-                        subtype="mime_type",
-                    )
+                    if output["data"]:
+                        self.create_warning(
+                            "No output mime type found from render_priority "
+                            f"(cell<{cell_index}>.output<{output_index}>",
+                            line=line,
+                            append_to=self.current_node,
+                            wtype=DEFAULT_LOG_TYPE,
+                            subtype="mime_type",
+                        )
                 else:
                     figure_options = (
                         self.get_cell_level_config(

--- a/myst_nb/ext/glue/directives.py
+++ b/myst_nb/ext/glue/directives.py
@@ -9,7 +9,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives as spec
 
 from myst_nb.core.render import MimeData, strip_latex_delimiters
-from myst_nb.core.variables import RetrievalError, is_sphinx, render_variable_output
+from myst_nb.core.variables import RetrievalError, is_sphinx, render_variable_outputs
 from myst_nb.ext.utils import DirectiveBase
 
 from .utils import (
@@ -62,7 +62,7 @@ class PasteAnyDirective(DirectiveBase):
                     self.line,
                 )
             ]
-        return render_variable_output(data, self.document, self.line, self.source)
+        return render_variable_outputs([data], self.document, self.line, self.source)
 
 
 def md_fmt(argument):
@@ -155,8 +155,8 @@ class PasteFigureDirective(DirectiveBase):
                 render.setdefault("image", {})[
                     key.replace("classes", "class")
                 ] = self.options[key]
-        paste_nodes = render_variable_output(
-            data, self.document, self.line, self.source, render=render
+        paste_nodes = render_variable_outputs(
+            [data], self.document, self.line, self.source, render=render
         )
 
         # note: most of this is copied directly from sphinx.Figure

--- a/myst_nb/ext/glue/roles.py
+++ b/myst_nb/ext/glue/roles.py
@@ -11,7 +11,7 @@ from myst_nb.core.render import MimeData
 from myst_nb.core.variables import (
     RetrievalError,
     format_plain_text,
-    render_variable_output,
+    render_variable_outputs,
 )
 from myst_nb.ext.utils import RoleBase
 
@@ -52,8 +52,8 @@ class PasteRoleAny(RoleBase):
             data = retrieve_glue_data(self.document, self.text)
         except RetrievalError as exc:
             return [], [glue_warning(str(exc), self.document, self.line)]
-        paste_nodes = render_variable_output(
-            data,
+        paste_nodes = render_variable_outputs(
+            [data],
             self.document,
             self.line,
             self.source,


### PR DESCRIPTION
Previously, it was assumed that a variable evaluation would only ever create 0 or 1 outputs.
Multiple are now allowed.
Also, error messages are appended with the output index.

closes #436 