### PR TITLE
📚 DOCS: Fix typos and add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         (?x)^(
             myst_nb/.+\.py|
         )$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    - id: codespell
+      args: ["-S", "*.ipynb"]

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -61,7 +61,7 @@ Optionally you can run `black` and `flake8` separately:
 
 Editors like VS Code also have automatic code reformat utilities, which can adhere to this standard.
 
-All functions and class methods should be annotated with types and include a docstring. The prefered docstring format is outlined in `MyST-NB/docstring.fmt.mustache` and can be used automatically with the
+All functions and class methods should be annotated with types and include a docstring. The preferred docstring format is outlined in `MyST-NB/docstring.fmt.mustache` and can be used automatically with the
 [autodocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) VS Code extension.
 
 ## Testing

--- a/docs/render/glue.md
+++ b/docs/render/glue.md
@@ -70,7 +70,7 @@ Below we'll calculate a few statistics of interest, and `glue()` them into the n
 ```{code-cell} ipython3
 # Calculate the mean of a bunch of random samples
 means = data[bootstrap_indices].mean(0)
-# Calcualte the 95% confidence interval for the mean
+# Calculate the 95% confidence interval for the mean
 clo, chi = np.percentile(means, [2.5, 97.5])
 
 # Store the values in our notebook
@@ -91,7 +91,7 @@ glue("boot_chi_notdisplayed", chi, display=False)
 You can also glue visualizations, such as matplotlib figures (here we use `display=False` to ensure that the figure isn't plotted twice):
 
 ```{code-cell} ipython3
-# Visualize the historgram with the intervals
+# Visualize the histogram with the intervals
 fig, ax = plt.subplots()
 ax.hist(means)
 for ln in [clo, chi]:

--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -276,7 +276,7 @@ class MditRenderMixin:
 
         # TODO how to output MyST Markdown?
         # currently text/markdown is set to be rendered as CommonMark only,
-        # with headings dissallowed,
+        # with headings disallowed,
         # to avoid "side effects" if the mime is discarded but contained
         # targets, etc, and because we can't parse headings within containers.
         # perhaps we could have a config option to allow this?
@@ -647,7 +647,7 @@ class NbElementRenderer:
             # data is b64-encoded as text
             data_bytes = a2b_base64(data.content)
         elif isinstance(data.content, str):
-            # ensure corrent line separator
+            # ensure correct line separator
             data_bytes = os.linesep.join(data.content.splitlines()).encode("utf-8")
         # create filename
         extension = (
@@ -800,7 +800,7 @@ class NbElementRenderer:
         self, data: MimeData, *, fmt: str, inline: bool, allow_headings: bool
     ) -> list[nodes.Element]:
         """Base render for a notebook markdown mime output (block or inline)."""
-        psuedo_element = nodes.Element()  # element to hold the parsed markdown
+        pseudo_element = nodes.Element()  # element to hold the parsed markdown
         current_parser = self.renderer.md
         current_md_config = self.renderer.md_config
         try:
@@ -828,7 +828,7 @@ class NbElementRenderer:
                 )
                 return []
 
-            with self.renderer.current_node_context(psuedo_element):
+            with self.renderer.current_node_context(pseudo_element):
                 self.renderer.nested_render_text(
                     data.string,
                     data.line or 0,
@@ -840,7 +840,7 @@ class NbElementRenderer:
             self.renderer.md = current_parser
             self.renderer.md_config = current_md_config
 
-        return psuedo_element.children
+        return pseudo_element.children
 
 
 class EntryPointError(Exception):

--- a/myst_nb/sphinx_.py
+++ b/myst_nb/sphinx_.py
@@ -363,7 +363,7 @@ class SelectMimeType(SphinxPostTransform):
 
 
 class NbMetadataCollector(EnvironmentCollector):
-    """Collect myst-nb specific metdata, and handle merging of parallel builds."""
+    """Collect myst-nb specific metadata, and handle merging of parallel builds."""
 
     @staticmethod
     def set_doc_data(env: SphinxEnvType, docname: str, key: str, value: Any) -> None:


### PR DESCRIPTION
Typos found via `codespell -S *.ipynb` and `typos --format brief`.