### PR TITLE
fix: bump `isort` version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       args: [--py37-plus]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
 


### PR DESCRIPTION
`isort` recently released [a bugfix](https://github.com/PyCQA/isort/pull/2078) that fixes Poetry installation. We can upgrade our `isort` version to accommodate this.