### PR TITLE
docs: update to latest `sphinx-design`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ rtd = [
     "plotly",
     "sphinx-book-theme~=0.3.0",
     "sphinx-copybutton",
-    "sphinx-design~=0.1.0",
+    "sphinx-design~=0.3.0",
     "sphinxcontrib-bibtex",
     "sympy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ rtd = [
     "plotly",
     "sphinx-book-theme~=0.3.0",
     "sphinx-copybutton",
-    "sphinx-design~=0.3.0",
+    "sphinx-design~=0.4.0",
     "sphinxcontrib-bibtex",
     "sympy",
 ]


### PR DESCRIPTION
A cryptic error message during our docs build is fixed in newer versions of `sphinx-design`. This PR just bumps that RTD dependency.