### PR TITLE
fix: use jsdelivr CDN for ipywidgets

### DIFF
--- a/docs/render/hiding.md
+++ b/docs/render/hiding.md
@@ -8,6 +8,7 @@ kernelspec:
 
 You can use Jupyter Notebook **cell tags** to control some of the behavior of
 the rendered notebook.[^download]
+If you are using cell tags for the first time, you can read more about them in this tutorial https://jupyterbook.org/en/stable/content/metadata.html#add-metadata-to-notebooks
 
 [^download]: This notebook can be downloaded as
             **{nb-download}`hiding.ipynb`** and {download}`hiding.md`

--- a/docs/render/interactive.md
+++ b/docs/render/interactive.md
@@ -90,6 +90,22 @@ show(p)
 
 ## ipywidgets
 
+:::{note}
+IPyWidgets uses a special JS package `@jupyter-widgets/html-manager` for rendering Jupyter widgets outside notebooks. `myst-nb` loads a specific version of this package, which may be incompatible with your installation of IPyWidgets. If this is the case, you might need to specify the appropriate `nb_ipywidgets_js` config value, e.g. for `0.20.0`
+```yaml
+
+sphinx:
+  recursive_update: true
+  config:
+    nb_ipywidgets_js:
+        # Load IPywidgets bundle for embedding.
+        "https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@0.20.0/dist/embed-amd.js":
+            "data-jupyter-widgets-cdn": "https://cdn.jsdelivr.net/npm/"
+            "crossorigin": "anonymous"
+```
+To determine which version of `@jupyter-widgets/html-manager` is required, find the `html-manager` JS package in the [`ipywidgets` repo](https://github.com/jupyter-widgets/ipywidgets), and identify its version.
+:::
+
 You may also run code for Jupyter Widgets in your document, and the interactive HTML
 outputs will embed themselves in your side. See [the ipywidgets documentation](https://ipywidgets.readthedocs.io/en/latest/user_install.html)
 for how to get set up in your own environment.

--- a/myst_nb/core/config.py
+++ b/myst_nb/core/config.py
@@ -64,7 +64,7 @@ def ipywidgets_js_factory() -> Dict[str, Dict[str, str]]:
             "crossorigin": "anonymous",
         },
         # Load IPywidgets bundle for embedding.
-        "https://unpkg.com/@jupyter-widgets/html-manager@^0.20.0/dist/embed-amd.js": {
+        "https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@0.20.0/dist/embed-amd.js": {
             "data-jupyter-widgets-cdn": "https://cdn.jsdelivr.net/npm/",
             "crossorigin": "anonymous",
         },

--- a/myst_nb/core/config.py
+++ b/myst_nb/core/config.py
@@ -64,7 +64,7 @@ def ipywidgets_js_factory() -> Dict[str, Dict[str, str]]:
             "crossorigin": "anonymous",
         },
         # Load IPywidgets bundle for embedding.
-        "https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@0.20.0/dist/embed-amd.js": {
+        "https://cdn.jsdelivr.net/npm/@jupyter-widgets/html-manager@1.0.6/dist/embed-amd.js": {
             "data-jupyter-widgets-cdn": "https://cdn.jsdelivr.net/npm/",
             "crossorigin": "anonymous",
         },


### PR DESCRIPTION
Should fix #458, supercedes https://github.com/executablebooks/MyST-NB/pull/469