### PR TITLE
MAINT: remove python=3.7 as EOL is June 2023

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
@@ -26,17 +26,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         sphinx: [">=5,<6"]
         include:
-          - os: ubuntu-latest
-            python-version: 3.7
-            sphinx: ">=4,<5"
           - os: windows-latest
-            python-version: 3.8
+            python-version: 3.9
             sphinx: ">=5,<6"
           - os: macos-latest
-            python-version: 3.8
+            python-version: 3.9
             sphinx: ">=5,<6"
 
     runs-on: ${{ matrix.os }}
@@ -82,7 +79,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: install flit
       run: |
         pip install flit~=3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -33,7 +32,7 @@ keywords = [
     "docutils",
     "sphinx",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "importlib_metadata",
     "ipython",

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py38-sphinx5
 [testenv]
 usedevelop = true
 
-[testenv:py{37,38,39,310}-sphinx{4,5}]
+[testenv:py{38,39,310}-sphinx{4,5}]
 extras = testing
 deps =
     sphinx4: sphinx>=4,<5


### PR DESCRIPTION
This PR removes `python==3.7` from the test suites and list of supported python versions. 

https://devguide.python.org/versions/

The deprecation date for `3.7` is coming up in June 2023. 

