### PR TITLE
Show traceback before raising ExecutionError

### DIFF
--- a/myst_nb/core/execute/cache.py
+++ b/myst_nb/core/execute/cache.py
@@ -80,12 +80,12 @@ class NotebookClientCache(NotebookClientBase):
         # handle success / failure cases
         # TODO do in try/except to be careful (in case of database write errors?
         if result.err is not None:
-            if self.nb_config.execution_raise_on_error:
-                raise ExecutionError(str(self.path)) from result.err
             msg = f"Executing notebook failed: {result.err.__class__.__name__}"
             if self.nb_config.execution_show_tb:
                 msg += f"\n{result.exc_string}"
             self.logger.warning(msg, subtype="exec")
+            if self.nb_config.execution_raise_on_error:
+                raise ExecutionError(str(self.path)) from result.err
             NbProjectRecord.set_traceback(stage_record.uri, result.exc_string, cache.db)
         else:
             self.logger.info(f"Executed notebook in {result.time:.2f} seconds")


### PR DESCRIPTION
When

```python
nb_execution_raise_on_error = True
nb_execution_show_tb = True
```

the traceback is not showed, which is very inconvenient when it happens during a CI job!

I guess it is only an issue of incompatibility between these two options, which should be fixed by this swap.

Does it make sense?
