### PR TITLE
[Doc] Fix broken pytest fixture

### DIFF
--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -188,7 +188,6 @@ class ModifiedNotebookClient(NotebookClient):
                 task_poll_kernel_alive,
             )
         )
-        print("EXECUTE", str(name))
         try:
             await self.task_poll_for_reply
         except asyncio.CancelledError:
@@ -203,7 +202,6 @@ class ModifiedNotebookClient(NotebookClient):
                     task_poll_output_msg.cancel()
             finally:
                 raise
-        print("EXECUTE DONE", str(name), cell.outputs)
         return cell.outputs
 
     eval_expression = run_sync(async_eval_expression)

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -188,6 +188,7 @@ class ModifiedNotebookClient(NotebookClient):
                 task_poll_kernel_alive,
             )
         )
+        print("EXECUTE", str(name))
         try:
             await self.task_poll_for_reply
         except asyncio.CancelledError:
@@ -202,6 +203,7 @@ class ModifiedNotebookClient(NotebookClient):
                     task_poll_output_msg.cancel()
             finally:
                 raise
+        print("EXECUTE DONE", str(name), cell.outputs)
         return cell.outputs
 
     eval_expression = run_sync(async_eval_expression)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,9 @@ def sphinx_run(sphinx_params, make_app, tmp_path):
         nb_path = TEST_FILE_DIR.joinpath(nb_file)
         assert nb_path.exists(), nb_path
         (srcdir / nb_file).parent.mkdir(exist_ok=True)
-        (srcdir / nb_file).write_text(nb_path.read_text(encoding="utf8"))
+        (srcdir / nb_file).write_text(
+            nb_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
 
     nocolor()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from nbdime.prettyprint import pretty_print_diff
 import nbformat as nbf
 import pytest
 import sphinx
-from sphinx.testing.path import path as sphinx_path
+from sphinx import version_info as sphinx_version_info
 from sphinx.util.console import nocolor
 
 pytest_plugins = "sphinx.testing.fixtures"
@@ -172,7 +172,7 @@ def sphinx_run(sphinx_params, make_app, tmpdir):
     if "working_dir" in sphinx_params:
         base_dir = Path(sphinx_params["working_dir"]) / str(uuid.uuid4())
     else:
-        base_dir = Path(tmpdir)
+        base_dir = tmpdir
     srcdir = base_dir / "source"
     srcdir.mkdir(exist_ok=True)
     os.chdir(base_dir)
@@ -194,8 +194,15 @@ def sphinx_run(sphinx_params, make_app, tmpdir):
 
     # For compatibility with multiple versions of sphinx, convert pathlib.Path to
     # sphinx.testing.path.path here.
+    app_srcdir: Any
+    if sphinx_version_info >= (7, 2):
+        app_srcdir = srcdir
+    else:
+        from sphinx.testing.path import path
+
+        app_srcdir = path(os.fspath(srcdir))
     app = make_app(
-        buildername=buildername, srcdir=sphinx_path(srcdir), confoverrides=confoverrides
+        buildername=buildername, srcdir=app_srcdir, confoverrides=confoverrides
     )
 
     yield SphinxFixture(app, sphinx_params["files"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 import uuid
+import re
 
 import bs4
 from docutils.nodes import image as image_node
@@ -269,7 +270,6 @@ def clean_doctree():
     return _func
 
 
-# TODO Remove when support for Sphinx<=6 is dropped,
 # comparison files will need updating
 # alternatively the resolution of https://github.com/ESSS/pytest-regressions/issues/32
 @pytest.fixture()
@@ -278,7 +278,12 @@ def file_regression(file_regression):
 
 
 class FileRegression:
-    ignores = (" translation_progress=\"{'total': 0, 'translated': 0}\"",)
+    ignores = (
+        # TODO: Remove when support for Sphinx<=6 is dropped,
+        re.escape(" translation_progress=\"{'total': 0, 'translated': 0}\""),
+        # TODO: Remove when support for Sphinx<7.2 is dropped,
+        r"original_uri=\"[^\"]*\"\s",
+    )
 
     def __init__(self, file_regression):
         self.file_regression = file_regression
@@ -288,5 +293,5 @@ class FileRegression:
 
     def _strip_ignores(self, data):
         for ig in self.ignores:
-            data = data.replace(ig, "")
+            data = re.sub(ig, "", data)
         return data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,11 +149,11 @@ def sphinx_params(request):
 
 
 @pytest.fixture()
-def sphinx_run(sphinx_params, make_app, tmpdir):
+def sphinx_run(sphinx_params, make_app, tmp_path):
     """A fixture to setup and run a sphinx build, in a sandboxed folder.
 
-    The `myst_nb` extension ius added by default,
-    and the first file will be set as the materdoc
+    The `myst_nb` extension is added by default,
+    and the first file will be set as the masterdoc
 
     """
     assert len(sphinx_params["files"]) > 0, sphinx_params["files"]
@@ -172,7 +172,7 @@ def sphinx_run(sphinx_params, make_app, tmpdir):
     if "working_dir" in sphinx_params:
         base_dir = Path(sphinx_params["working_dir"]) / str(uuid.uuid4())
     else:
-        base_dir = tmpdir
+        base_dir = tmp_path
     srcdir = base_dir / "source"
     srcdir.mkdir(exist_ok=True)
     os.chdir(base_dir)
@@ -194,7 +194,6 @@ def sphinx_run(sphinx_params, make_app, tmpdir):
 
     # For compatibility with multiple versions of sphinx, convert pathlib.Path to
     # sphinx.testing.path.path here.
-    app_srcdir: Any
     if sphinx_version_info >= (7, 2):
         app_srcdir = srcdir
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def test_quickstart(tmp_path: Path, sphinx_run, make_app):
     """Test the quickstart CLI builds a valid sphinx project."""
     project_path = tmp_path / "project"
     quickstart([str(project_path)])
-    assert {p.name for p in path.iterdir()} == {
+    assert {p.name for p in project_path.iterdir()} == {
         ".gitignore",
         "conf.py",
         "index.md",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from sphinx import version_info as sphinx_version_info
 from myst_nb.cli import md_to_nb, quickstart
 
 
-def test_quickstart(tmp_path: Path, sphinx_run, make_app):
+def test_quickstart(tmp_path: Path, make_app):
     """Test the quickstart CLI builds a valid sphinx project."""
     project_path = tmp_path / "project"
     quickstart([str(project_path)])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ kernelspec:
 +++
 next cell
 """,
-        "utf8",
+        "utf-8",
     )
     md_to_nb([str(path)])
     assert path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def test_quickstart(tmp_path: Path, make_app):
     app = make_app(srcdir=app_srcdir, buildername="html")
     app.build()
     assert app._warning.getvalue().strip() == ""
-    assert (path / "_build/html/index.html").exists()
+    assert (project_path / "_build/html/index.html").exists()
 
 
 def test_md_to_nb(tmp_path: Path):

--- a/tests/test_codecell_file.py
+++ b/tests/test_codecell_file.py
@@ -31,11 +31,14 @@ def test_codecell_file(sphinx_run, file_regression, check_nbs, get_test_path):
     }
     try:
         file_regression.check(
-            sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf8"
+            sphinx_run.get_nb(),
+            check_fn=check_nbs,
+            extension=".ipynb",
+            encoding="utf-8",
         )
     finally:
         file_regression.check(
-            sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+            sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
         )
 
 
@@ -73,9 +76,12 @@ def test_codecell_file_warnings(sphinx_run, file_regression, check_nbs, get_test
     }
     try:
         file_regression.check(
-            sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf8"
+            sphinx_run.get_nb(),
+            check_fn=check_nbs,
+            extension=".ipynb",
+            encoding="utf-8",
         )
     finally:
         file_regression.check(
-            sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+            sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
         )

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -12,5 +12,5 @@ def test_sphinx(sphinx_run, clean_doctree, file_regression):
     doctree = clean_doctree(sphinx_run.get_resolved_doctree("with_eval"))
     file_regression.check(
         doctree.pformat(),
-        encoding="utf8",
+        encoding="utf-8",
     )

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -12,7 +12,10 @@ from myst_nb.sphinx_ import NbMetadataCollector
 def regress_nb_doc(file_regression, sphinx_run, check_nbs):
     try:
         file_regression.check(
-            sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf8"
+            sphinx_run.get_nb(),
+            check_fn=check_nbs,
+            extension=".ipynb",
+            encoding="utf-8",
         )
     finally:
         doctree_string = sphinx_run.get_doctree().pformat()
@@ -31,7 +34,7 @@ def regress_nb_doc(file_regression, sphinx_run, check_nbs):
             doctree_string = doctree_string.replace(
                 Path(sphinx_run.app.srcdir).as_posix() + "/", ""
             )
-        file_regression.check(doctree_string, extension=".xml", encoding="utf8")
+        file_regression.check(doctree_string, extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("basic_unrun.ipynb", conf={"nb_execution_mode": "auto"})
@@ -112,7 +115,7 @@ def test_exclude_path(sphinx_run, file_regression):
     assert not NbMetadataCollector.new_exec_data(sphinx_run.env)
     assert "Executing" not in sphinx_run.status(), sphinx_run.status()
     file_regression.check(
-        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
     )
 
 
@@ -317,7 +320,7 @@ def test_nb_exec_table(sphinx_run, file_regression):
     # print(sphinx_run.status())
     assert not sphinx_run.warnings()
     file_regression.check(
-        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
     )
     # print(sphinx_run.get_html())
     rows = sphinx_run.get_html().select("table.docutils tr")

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -112,5 +112,5 @@ def test_parser(sphinx_run, clean_doctree, file_regression):
     doctree = clean_doctree(sphinx_run.get_resolved_doctree("with_glue"))
     file_regression.check(
         doctree.pformat(),
-        encoding="utf8",
+        encoding="utf-8",
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,7 +70,7 @@ def test_complex_outputs(sphinx_run, file_regression):
     file_regression.check(doctree_string, extension=".xml", encoding="utf8")
 
     filenames = {
-        p.replace(".jpeg", ".jpg").name
+        p.name.replace(".jpeg", ".jpg")
         for p in Path(
             os.fspath(sphinx_run.app.srcdir / "_build" / "jupyter_execute")
         ).iterdir()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -24,7 +24,7 @@ def test_basic_run(sphinx_run, file_regression):
         "name": "python3",
     }
     file_regression.check(
-        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
     )
 
     filenames = {
@@ -67,7 +67,7 @@ def test_complex_outputs(sphinx_run, file_regression):
         doctree_string = doctree_string.replace(
             Path(sphinx_run.app.srcdir).as_posix() + "/", ""
         )
-    file_regression.check(doctree_string, extension=".xml", encoding="utf8")
+    file_regression.check(doctree_string, extension=".xml", encoding="utf-8")
 
     filenames = {
         p.name.replace(".jpeg", ".jpg")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,7 +28,7 @@ def test_basic_run(sphinx_run, file_regression):
     )
 
     filenames = {
-        p for p in (sphinx_run.app.srcdir / "_build" / "jupyter_execute").listdir()
+        p.name for p in Path(os.fspath(sphinx_run.app.srcdir / "_build" / "jupyter_execute")).iterdir()
     }
     assert filenames == {"basic_run.ipynb"}
 
@@ -67,8 +67,8 @@ def test_complex_outputs(sphinx_run, file_regression):
     file_regression.check(doctree_string, extension=".xml", encoding="utf8")
 
     filenames = {
-        p.replace(".jpeg", ".jpg")
-        for p in (sphinx_run.app.srcdir / "_build" / "jupyter_execute").listdir()
+        p.replace(".jpeg", ".jpg").name
+        for p in Path(os.fspath(sphinx_run.app.srcdir / "_build" / "jupyter_execute")).iterdir()
     }
     # print(filenames)
     assert filenames == {

--- a/tests/test_render_outputs.py
+++ b/tests/test_render_outputs.py
@@ -24,7 +24,7 @@ def test_basic_run(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("basic_run")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("file_level_config.md")
@@ -32,7 +32,7 @@ def test_file_level_config_md(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("file_level_config")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("file_level_config.ipynb")
@@ -40,7 +40,7 @@ def test_file_level_config_ipynb(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("file_level_config")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("complex_outputs.ipynb", conf={"nb_execution_mode": "off"})
@@ -49,7 +49,7 @@ def test_complex_outputs(sphinx_run, clean_doctree, file_regression):
     assert sphinx_run.warnings() == ""
     doctree = clean_doctree(sphinx_run.get_resolved_doctree("complex_outputs"))
     file_regression.check(
-        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf8"
+        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf-8"
     )
 
 
@@ -63,7 +63,7 @@ def test_complex_outputs_latex(sphinx_run, clean_doctree, file_regression):
     assert sphinx_run.warnings() == ""
     doctree = clean_doctree(sphinx_run.get_resolved_doctree("complex_outputs"))
     file_regression.check(
-        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf8"
+        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf-8"
     )
 
 
@@ -76,7 +76,7 @@ def test_stderr_remove(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("basic_stderr")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("basic_stderr.ipynb", conf={"nb_execution_mode": "off"})
@@ -87,7 +87,7 @@ def test_stderr_tag(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("basic_stderr")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params(
@@ -99,7 +99,7 @@ def test_merge_streams(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("merge_streams")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params(
@@ -112,7 +112,7 @@ def test_metadata_image(sphinx_run, clean_doctree, file_regression):
     assert sphinx_run.warnings() == ""
     doctree = clean_doctree(sphinx_run.get_resolved_doctree("metadata_image"))
     file_regression.check(
-        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf8"
+        doctree.pformat().replace(".jpeg", ".jpg"), extension=".xml", encoding="utf-8"
     )
 
 
@@ -132,7 +132,7 @@ def test_metadata_figure(sphinx_run, clean_doctree, file_regression):
         '<figure align="default" ids="fun-fish" names="fun-fish">',
     )
     file_regression.check(
-        doctree_string.replace(".jpeg", ".jpg"), extension=".xml", encoding="utf8"
+        doctree_string.replace(".jpeg", ".jpg"), extension=".xml", encoding="utf-8"
     )
 
 
@@ -143,7 +143,7 @@ def test_unknown_mimetype(sphinx_run, file_regression):
     warning = "skipping unknown output mime type: unknown [mystnb.unknown_mime_type]"
     assert warning in sphinx_run.warnings()
     doctree = sphinx_run.get_resolved_doctree("unknown_mimetype")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
 
 @pytest.mark.sphinx_params("hide_cell_content.ipynb", conf={"nb_execution_mode": "off"})
@@ -152,4 +152,4 @@ def test_hide_cell_content(sphinx_run, file_regression):
     sphinx_run.build()
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("hide_cell_content")
-    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf8")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")

--- a/tests/test_text_based.py
+++ b/tests/test_text_based.py
@@ -27,10 +27,10 @@ def test_basic_run(sphinx_run, file_regression, check_nbs):
         "name": "python3",
     }
     file_regression.check(
-        sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf8"
+        sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf-8"
     )
     file_regression.check(
-        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
     )
 
 
@@ -52,10 +52,10 @@ def test_basic_run_exec_off(sphinx_run, file_regression, check_nbs):
     assert sphinx_run.env.metadata["basic_unrun"]["author"] == "Chris"
 
     file_regression.check(
-        sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf8"
+        sphinx_run.get_nb(), check_fn=check_nbs, extension=".ipynb", encoding="utf-8"
     )
     file_regression.check(
-        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf8"
+        sphinx_run.get_doctree().pformat(), extension=".xml", encoding="utf-8"
     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes an instance where a `myst-nb` test fixture was using a test fixture that was previously provided by sphinx but was removed sometime between the release of `6.2.1` and `7.2.6`. Closes #545. This should also unblock a new release.

## Changes

- Swapped out the `tempdir` fixture for `pytest`'s `tmpdir` fixture as a drop-in replacement.
