### PR TITLE
Update readthedocs Config File to fix Test Error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: "3.8"
   install:
       - method: pip
         path: .


### PR DESCRIPTION
The configuration file

```
python:
  version: "3.8"
```

syntax [has been deprecated](https://docs.readthedocs.io/en/stable/config-file/v2.html#python) by readthedocs.

Instead,

```
uild:
  os: ubuntu-22.04
  tools:
    python: "3.11"
```

has to be used. This would fix test errors caused by the readthedocs build (eg. here: https://github.com/executablebooks/MyST-NB/pull/553).