### PR TITLE
maint: bump minimum Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx: [">=5.0,<=7.*"]  # Newest Sphinx (any)
         myst-parser: [">=1.0.0,<=2.*"]  # Newest MyST Parser (any)
         include:
@@ -41,7 +41,7 @@ jobs:
             myst-parser: ">=2.0"
           # Oldest known-compatible dependencies
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             sphinx: "~=5.0"
             myst-parser: "~=1.0.0"
           # Newest known-compatible dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -35,7 +34,7 @@ keywords = [
     "docutils",
     "sphinx",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "importlib_metadata",
     "ipython",

--- a/tox.ini
+++ b/tox.ini
@@ -11,16 +11,17 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py39-sphinx5
+envlist = py311-sphinx7
 
 [testenv]
 usedevelop = true
 
-[testenv:py{38,39,310}-sphinx{4,5}]
+[testenv:py{39,310,311,312}-sphinx{5,6,7}]
 extras = testing
 deps =
-    sphinx4: sphinx>=4,<5
     sphinx5: sphinx>=5,<6
+    sphinx6: sphinx>=6,<7
+    sphinx7: sphinx>=7,<8
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
We should try and support SPEC 0, which will keep our development burden down. As such, this PR drops 3.8