### PR TITLE
maint: use `findall` instead of `traverse`

### DIFF
--- a/myst_nb/docutils_.py
+++ b/myst_nb/docutils_.py
@@ -207,7 +207,7 @@ class Parser(MystParser):
                 css_paths.append(
                     nb_renderer.write_file(
                         ["mystnb.css"],
-                        import_resources.read_binary(static, "mystnb.css"),
+                        (import_resources.files(static) / "mystnb.css").read_bytes(),
                         overwrite=True,
                     )
                 )

--- a/myst_nb/ext/execution_tables.py
+++ b/myst_nb/ext/execution_tables.py
@@ -17,6 +17,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 
+from myst_nb._compat import findall
 from myst_nb.sphinx_ import NbMetadataCollector, SphinxEnvType
 
 SPHINX_LOGGER = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ class ExecutionStatsPostTransform(SphinxPostTransform):
     def run(self, **kwargs) -> None:
         """Replace the placeholder node with the final table nodes."""
         self.env: SphinxEnvType
-        for node in self.document.traverse(ExecutionStatsNode):
+        for node in findall(self.document)(ExecutionStatsNode):
             node.replace_self(
                 make_stat_table(
                     self.env.docname, NbMetadataCollector.get_doc_data(self.env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ testing = [
     "matplotlib==3.7.*",
     "nbdime",
     "numpy",
-    "pandas",
+    "pandas==1.5.*",
     "pyarrow",
     "pytest~=7.1",
     "pytest-cov>=3,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ testing = [
     "nbdime",
     "numpy",
     "pandas",
+    "pyarrow",
     "pytest~=7.1",
     "pytest-cov>=3,<5",
     "pytest-regressions",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,7 +248,8 @@ def check_nbs():
 def clean_doctree():
     def _func(doctree):
         if os.name == "nt":  # on Windows file paths are absolute
-            for node in doctree.traverse(image_node):  # type: image_node
+            findall = getattr(doctree, "findall", doctree.traverse)
+            for node in findall(image_node):  # type: image_node
                 if "candidates" in node:
                     node["candidates"]["*"] = (
                         "_build/jupyter_execute/"

--- a/tests/test_execute/test_complex_outputs_unrun_auto.xml
+++ b/tests/test_execute/test_complex_outputs_unrun_auto.xml
@@ -214,7 +214,7 @@
                             (√5⋅ⅈ)      ⋅⎜─ - ──────⎟ + (-√5⋅ⅈ)      ⋅⎜─ + ──────⎟
                                          ⎝2     5   ⎠                 ⎝2     5   ⎠
                     <container mime_type="image/png">
-                        <image candidates="{'*': '_build/jupyter_execute/a04ee1a78ad33a6345469c5f6d84ff6ef0bfcb4d9e3a8d10eaa7ea3f445bbc5c.png'}" uri="_build/jupyter_execute/a04ee1a78ad33a6345469c5f6d84ff6ef0bfcb4d9e3a8d10eaa7ea3f445bbc5c.png">
+                        <image candidates="{'*': '_build/jupyter_execute/9bc81205a14646a235d284d1b68223d17f30f7f1d3d8ed3e52cf47830b02e3bb.png'}" uri="_build/jupyter_execute/9bc81205a14646a235d284d1b68223d17f30f7f1d3d8ed3e52cf47830b02e3bb.png">
                     <container mime_type="text/latex">
                         <math_block classes="output text_latex" nowrap="False" number="True" xml:space="preserve">
                             \displaystyle \left(\sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} - \frac{2 \sqrt{5} i}{5}\right) + \left(- \sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} + \frac{2 \sqrt{5} i}{5}\right)

--- a/tests/test_execute/test_complex_outputs_unrun_cache.xml
+++ b/tests/test_execute/test_complex_outputs_unrun_cache.xml
@@ -214,7 +214,7 @@
                             (√5⋅ⅈ)      ⋅⎜─ - ──────⎟ + (-√5⋅ⅈ)      ⋅⎜─ + ──────⎟
                                          ⎝2     5   ⎠                 ⎝2     5   ⎠
                     <container mime_type="image/png">
-                        <image candidates="{'*': '_build/jupyter_execute/a04ee1a78ad33a6345469c5f6d84ff6ef0bfcb4d9e3a8d10eaa7ea3f445bbc5c.png'}" uri="_build/jupyter_execute/a04ee1a78ad33a6345469c5f6d84ff6ef0bfcb4d9e3a8d10eaa7ea3f445bbc5c.png">
+                        <image candidates="{'*': '_build/jupyter_execute/9bc81205a14646a235d284d1b68223d17f30f7f1d3d8ed3e52cf47830b02e3bb.png'}" uri="_build/jupyter_execute/9bc81205a14646a235d284d1b68223d17f30f7f1d3d8ed3e52cf47830b02e3bb.png">
                     <container mime_type="text/latex">
                         <math_block classes="output text_latex" nowrap="False" number="True" xml:space="preserve">
                             \displaystyle \left(\sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} - \frac{2 \sqrt{5} i}{5}\right) + \left(- \sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} + \frac{2 \sqrt{5} i}{5}\right)

--- a/tests/test_execute/test_custom_convert_auto.xml
+++ b/tests/test_execute/test_custom_convert_auto.xml
@@ -18,4 +18,4 @@
                         <literal_block classes="output text_plain" language="myst-ansi" xml:space="preserve">
                             <Figure size 640x480 with 1 Axes>
                     <container mime_type="image/png">
-                        <image candidates="{'*': '_build/jupyter_execute/79c62be209810029709c370dc93d2e5dba383561eb0d8bc1ce8b30db61641985.png'}" uri="_build/jupyter_execute/79c62be209810029709c370dc93d2e5dba383561eb0d8bc1ce8b30db61641985.png">
+                        <image candidates="{'*': '_build/jupyter_execute/a2e637020dfe58f670ba2c942d7a55e49ba48bed09312569ee15a84f5ac680cb.png'}" uri="_build/jupyter_execute/a2e637020dfe58f670ba2c942d7a55e49ba48bed09312569ee15a84f5ac680cb.png">

--- a/tests/test_execute/test_custom_convert_cache.xml
+++ b/tests/test_execute/test_custom_convert_cache.xml
@@ -18,4 +18,4 @@
                         <literal_block classes="output text_plain" language="myst-ansi" xml:space="preserve">
                             <Figure size 640x480 with 1 Axes>
                     <container mime_type="image/png">
-                        <image candidates="{'*': '_build/jupyter_execute/79c62be209810029709c370dc93d2e5dba383561eb0d8bc1ce8b30db61641985.png'}" uri="_build/jupyter_execute/79c62be209810029709c370dc93d2e5dba383561eb0d8bc1ce8b30db61641985.png">
+                        <image candidates="{'*': '_build/jupyter_execute/a2e637020dfe58f670ba2c942d7a55e49ba48bed09312569ee15a84f5ac680cb.png'}" uri="_build/jupyter_execute/a2e637020dfe58f670ba2c942d7a55e49ba48bed09312569ee15a84f5ac680cb.png">


### PR DESCRIPTION
This deprecation was introduced in docutils 0.18.2

This PR also updates deprecated usage of `importlib.resources`, and updates & pins the pandas regression tests.