### PR TITLE
Fix image metadata being used in wrong cell

### DIFF
--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -660,7 +660,7 @@ class NbElementRenderer:
         # TODO backwards-compatible re-naming to image_options?
         image_options = self.renderer.get_cell_level_config(
             "render_image_options", data.cell_metadata, line=data.line
-        )
+        ).copy()
         # Overwrite with metadata stored in output
         image_options.update(
             {

--- a/tests/notebooks/complex_outputs.ipynb
+++ b/tests/notebooks/complex_outputs.ipynb
@@ -280,6 +280,10 @@
       ]
      },
      "metadata": {
+      "image/png": {
+          "width": 432,
+          "height": 288
+      },
       "needs_background": "light"
      },
      "output_type": "display_data"

--- a/tests/test_parser/test_complex_outputs.xml
+++ b/tests/test_parser/test_complex_outputs.xml
@@ -130,7 +130,7 @@
                 <container classes="cell_output" nb_element="cell_code_output">
                     <container nb_element="mime_bundle">
                         <container mime_type="image/png">
-                            <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="400" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png">
+                            <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="288" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png" width="432">
                         <container mime_type="text/plain">
                             <literal_block classes="output text_plain" language="myst-ansi" xml:space="preserve">
                                 <Figure size 432x288 with 1 Axes>
@@ -244,7 +244,7 @@
             <container classes="cell_output" nb_element="cell_code_output">
                 <container nb_element="mime_bundle">
                     <container mime_type="image/png">
-                        <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" height="400" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
+                        <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
                     <container mime_type="text/latex">
                         <math_block classes="output text_latex" nowrap="False" number="True" xml:space="preserve">
                             \displaystyle \left(\sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} - \frac{2 \sqrt{5} i}{5}\right) + \left(- \sqrt{5} i\right)^{\alpha} \left(\frac{1}{2} + \frac{2 \sqrt{5} i}{5}\right)

--- a/tests/test_render_outputs/test_complex_outputs.xml
+++ b/tests/test_render_outputs/test_complex_outputs.xml
@@ -123,7 +123,7 @@
                         plt.ylabel(r'a y label with latex $\alpha$')
                         plt.legend();
                 <container classes="cell_output" nb_element="cell_code_output">
-                    <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="400" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png">
+                    <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="288" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png" width="432">
     <section ids="tables-with-pandas" names="tables\ (with\ pandas)">
         <title>
             Tables (with pandas)
@@ -208,7 +208,7 @@
                     f = y(n)-2*y(n-1/sym.pi)-5*y(n-2)
                     sym.rsolve(f,y(n),[1,4])
             <container classes="cell_output" nb_element="cell_code_output">
-                <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" height="400" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
+                <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
         <container cell_index="25" cell_metadata="{}" classes="cell" exec_count="7" nb_element="cell_code">
             <container classes="cell_input" nb_element="cell_code_source">
                 <literal_block language="ipython3" linenos="False" xml:space="preserve">

--- a/tests/test_render_outputs/test_complex_outputs_latex.xml
+++ b/tests/test_render_outputs/test_complex_outputs_latex.xml
@@ -123,7 +123,7 @@
                         plt.ylabel(r'a y label with latex $\alpha$')
                         plt.legend();
                 <container classes="cell_output" nb_element="cell_code_output">
-                    <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="400" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png">
+                    <image candidates="{'*': '_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png'}" height="288" uri="_build/jupyter_execute/16832f45917c1c9862c50f0948f64a498402d6ccde1f3a291da17f240797b160.png" width="432">
     <section ids="tables-with-pandas" names="tables\ (with\ pandas)">
         <title>
             Tables (with pandas)
@@ -168,7 +168,7 @@
                     f = y(n)-2*y(n-1/sym.pi)-5*y(n-2)
                     sym.rsolve(f,y(n),[1,4])
             <container classes="cell_output" nb_element="cell_code_output">
-                <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" height="400" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
+                <image candidates="{'*': '_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png'}" uri="_build/jupyter_execute/8c43e5c8cccf697754876b7fec1b0a9b731d7900bb585e775a5fa326b4de8c5a.png">
         <container cell_index="25" cell_metadata="{}" classes="cell" exec_count="7" nb_element="cell_code">
             <container classes="cell_input" nb_element="cell_code_source">
                 <literal_block language="ipython3" linenos="False" xml:space="preserve">


### PR DESCRIPTION
Fix bug pointed out in https://github.com/executablebooks/MyST-NB/pull/588#pullrequestreview-2040630500 caused by reusing the image_options dict. Fixes #605.

Seems like in my previous PR I didn’t understand the tests enough to realize that I changed them to nonsense, but now I do.

Sorry for that!

cc @OriolAbril