### PR TITLE
fix(docs): extra comma forgotten

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ Tags are a list of strings under the `tags` key in the cell metadata, e.g.
   "cell_type": "code",
   "source": ["print('hello world')"],
   "metadata": {
-    "tags": ["my-tag1", "my-tag2"],
+    "tags": ["my-tag1", "my-tag2"]
   }
 }
 ```


### PR DESCRIPTION
Hello,

Just to mention that there is an extra comma in this example that makes this JSON invalid :-)