### PR TITLE
DOCS: set printoptions to disable modern scalar printing

### DIFF
--- a/docs/render/glue.md
+++ b/docs/render/glue.md
@@ -54,6 +54,8 @@ We'll hide most of this process below, to focus on the glueing part.
 
 # Simulate some data and bootstrap the mean of the data
 import numpy as np
+np.set_printoptions(legacy="1.25")
+
 import pandas as pd
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
For now this fixes our docs. We should develop some guidance on this for users.