### PR TITLE
MAINT: fix sphinx 8.0 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,11 @@ jobs:
         include:
           # Just check the other platforms once
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
             sphinx: "~=8.0"
             myst-parser: "~=4.0"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.12"
             sphinx: "~=8.0"
             myst-parser: "~=4.0"
           # Oldest known-compatible dependencies
@@ -33,6 +33,11 @@ jobs:
             python-version: "3.9"
             sphinx: "==5.0.0"
             myst-parser: "==1.0.0"
+          # Mid-range dependencies
+          - os: ubuntu-latest
+            python-version: "3.11"
+            sphinx: "==7.0.0"
+            myst-parser: "==2.0.0"
           # Newest known-compatible dependencies
           - os: ubuntu-latest
             python-version: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,11 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
             sphinx: "~=8.0"
-            myst-parser: "~=2.0"
+            myst-parser: "~=4.0"
           - os: macos-latest
             python-version: "3.10"
             sphinx: "~=8.0"
-            myst-parser: "~=2.0"
+            myst-parser: "~=4.0"
           # Oldest known-compatible dependencies
           - os: ubuntu-latest
             python-version: "3.9"
@@ -36,8 +36,8 @@ jobs:
           # Newest known-compatible dependencies
           - os: ubuntu-latest
             python-version: "3.12"
-            sphinx: "==8.0.0"
-            myst-parser: "==2.0.0"
+            sphinx: "==8.0.2"
+            myst-parser: "==4.0.0"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,17 +16,17 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        sphinx: [">=5,<8"]  # Newest Sphinx (any)
+        sphinx: [">=5,<9"]  # Newest Sphinx (any)
         myst-parser: [">=1,<3"]  # Newest MyST Parser (any)
         include:
           # Just check the other platforms once
           - os: windows-latest
             python-version: "3.10"
-            sphinx: "~=7.0"
+            sphinx: "~=8.0"
             myst-parser: "~=2.0"
           - os: macos-latest
             python-version: "3.10"
-            sphinx: "~=7.0"
+            sphinx: "~=8.0"
             myst-parser: "~=2.0"
           # Oldest known-compatible dependencies
           - os: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           # Newest known-compatible dependencies
           - os: ubuntu-latest
             python-version: "3.12"
-            sphinx: "==7.0.0"
+            sphinx: "==8.0.0"
             myst-parser: "==2.0.0"
 
     runs-on: ${{ matrix.os }}

--- a/myst_nb/core/read.py
+++ b/myst_nb/core/read.py
@@ -68,7 +68,7 @@ def create_nb_reader(
     # we check suffixes ordered by longest first, to ensure we get the "closest" match
     iterator = sorted(readers.items(), key=lambda x: len(x[0]), reverse=True)
     for suffix, (reader, reader_kwargs, commonmark_only) in iterator:
-        if path.endswith(suffix):
+        if path.suffix == suffix:
             if isinstance(reader, str):
                 # attempt to load the reader as an object path
                 reader = import_object(reader)

--- a/myst_nb/core/read.py
+++ b/myst_nb/core/read.py
@@ -68,7 +68,7 @@ def create_nb_reader(
     # we check suffixes ordered by longest first, to ensure we get the "closest" match
     iterator = sorted(readers.items(), key=lambda x: len(x[0]), reverse=True)
     for suffix, (reader, reader_kwargs, commonmark_only) in iterator:
-        if path.suffix == suffix:
+        if Path(path).suffix == suffix:
             if isinstance(reader, str):
                 # attempt to load the reader as an object path
                 reader = import_object(reader)

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,13 @@ envlist = py311-sphinx7
 [testenv]
 usedevelop = true
 
-[testenv:py{39,310,311,312}-sphinx{5,6,7}]
+[testenv:py{39,310,311,312}-sphinx{5,6,7,8}]
 extras = testing
 deps =
     sphinx5: sphinx>=5,<6
     sphinx6: sphinx>=6,<7
     sphinx7: sphinx>=7,<8
+    sphinx8: sphinx>=8,<9
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
It's beyond the scope for this PR, but I would also suggest adding a job that pulls the development versions of dependencies, even if it's just in a job that runs from a e.g. weekly cron; so end users would not run into incompatibilities when an upstream release is out.

(We do this for sphinx extensions and pytest plugins; as well as for libraries that more and more test against nightly wheels; and it's really nice from the release manager perspective as it removes a lot of cases for a rushed compatibility release). 


Closes #619 
