### PR TITLE
MAINT: only doing monthly pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,9 @@ exclude: >
       tests/.*\.txt
     )$
 
+ci:
+  autoupdate_schedule: 'monthly'
+
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
When maintainer capacity is limited on a low-traffic repo, there is no need for the noise from the automated weekly PRs