### PR TITLE
Add `:only:` option for code cells

### DIFF
--- a/myst_nb/core/read.py
+++ b/myst_nb/core/read.py
@@ -86,6 +86,7 @@ def create_nb_reader(
                 config=md_config,
                 add_source_map=True,
                 path=path,
+                builder=nb_config.builder_name
             ),
             md_config,
             {"type": "plugin", "name": "myst_nb_md"},
@@ -176,6 +177,7 @@ def read_myst_markdown_notebook(
     raw_directive="{raw-cell}",
     add_source_map=False,
     path: str | Path | None = None,
+    builder: str = "",
 ) -> nbf.NotebookNode:
     """Convert text written in the myst format to a notebook.
 
@@ -260,9 +262,10 @@ def read_myst_markdown_notebook(
                 )
             meta = nbf.from_dict(options)
             source_map.append(token_map[0] + 1)
-            notebook.cells.append(
-                nbf_version.new_code_cell(source="\n".join(body_lines), metadata=meta)
-            )
+            if "only" not in options or options["only"] == builder:
+                notebook.cells.append(
+                    nbf_version.new_code_cell(source="\n".join(body_lines), metadata=meta)
+                )
             md_metadata = {}
             md_start_line = token_map[1]
 

--- a/myst_nb/sphinx_.py
+++ b/myst_nb/sphinx_.py
@@ -80,6 +80,7 @@ class Parser(MystParser):
 
         # get notebook rendering configuration
         nb_config: NbParserConfig = self.env.mystnb_config
+        nb_config.builder_name = self.env.app.builder.name
 
         # create a reader for the notebook
         nb_reader = create_nb_reader(document_path, md_config, nb_config, inputstring)


### PR DESCRIPTION
I made this primarily for myself but thought should make a PR if there would be any interest in merging. I'm happy to add tests/documentation, but I'd like to get an OK that the implementation is fine first.

Also, as far as I can tell, `NbParserConfig.builder_name` isn't used by anything, so I just co-opted it. 