### PR TITLE
MAINT: adding python 3.13 to CI and classifiers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         sphinx: [">=5,<9"]  # Newest Sphinx (any)
         myst-parser: [">=1,<3"]  # Newest MyST Parser (any)
         include:
@@ -52,6 +52,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: pip
     - name: Install myst-nb with Sphinx ${{ matrix.sphinx }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,8 +55,13 @@ jobs:
         allow-prereleases: true
         cache: pip
     - name: Install myst-nb with Sphinx ${{ matrix.sphinx }}
+      shell: bash
       run: |
         pip install --upgrade pip
+        # Temporary: for python 3.13 we need the nightly pandas wheels
+        if [[ ${{ matrix.python-version }} == '3.13' ]] ; then
+          PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pip install -U pandas pyarrow
+        fi
         pip install --upgrade "Sphinx${{ matrix.sphinx }}" "myst-parser${{ matrix.myst-parser }}" -e .[testing]
 
     - name: Run pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,9 +58,9 @@ jobs:
       shell: bash
       run: |
         pip install --upgrade pip
-        # Temporary: for python 3.13 we need the nightly pandas wheels
+        # Temporary: for python 3.13 we need the nightly pyarrow wheels
         if [[ ${{ matrix.python-version }} == '3.13' ]] ; then
-          PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pip install -U pandas pyarrow
+          PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pip install --pre pyarrow
         fi
         pip install --upgrade "Sphinx${{ matrix.sphinx }}" "myst-parser${{ matrix.myst-parser }}" -e .[testing]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py311-sphinx7
 [testenv]
 usedevelop = true
 
-[testenv:py{39,310,311,312}-sphinx{5,6,7,8}]
+[testenv:py{39,310,311,312,313}-sphinx{5,6,7,8}]
 extras = testing
 deps =
     sphinx5: sphinx>=5,<6


### PR DESCRIPTION
I see failing tests locally, but some of those are failing with other python versions, too, so I'll use the CI here to check for actual issues.