### PR TITLE
BUG: using rstrip to preserve indents

### DIFF
--- a/myst_nb/core/utils.py
+++ b/myst_nb/core/utils.py
@@ -25,11 +25,11 @@ def coalesce_streams(outputs: list[NotebookNode]) -> list[NotebookNode]:
     for output in outputs:
         if output["output_type"] == "stream":
             if output["name"] in streams:
-                out = output["text"].strip()
+                out = output["text"].rstrip()
                 if out:
                     streams[output["name"]]["text"] += f"{out}\n"
             else:
-                output["text"] = output["text"].strip() + "\n"
+                output["text"] = output["text"].rstrip() + "\n"
                 new_outputs.append(output)
                 streams[output["name"]] = output
         else:


### PR DESCRIPTION
This addresses @chrisjsewell review in https://github.com/executablebooks/MyST-NB/pull/604/files#r1773425274