### PR TITLE
CI: adding devdeps testing and cron and workflow dispatch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,12 +61,12 @@ jobs:
     - name: Install myst-nb with Sphinx ${{ matrix.sphinx }}
       shell: bash
       run: |
-        pip install --upgrade pip
         # Temporary: for python 3.13 we need the nightly pyarrow wheels
         if [[ ${{ matrix.python-version }} == '3.13' ]] ; then
           PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pip install --pre pyarrow
         fi
         pip install --upgrade "Sphinx${{ matrix.sphinx }}" "myst-parser${{ matrix.myst-parser }}" -e .[testing]
+        pip freeze
 
     - name: Run pytest
       run: pytest --durations=10
@@ -84,8 +84,8 @@ jobs:
         cache: pip
     - name: Install dependencies
       run: |
-        pip install --upgrade pip
         pip install -e .[testing]
+        pip freeze
 
     - name: Run pytest
       run: pytest --durations=10 --cov=myst_nb --cov-report=xml --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - 'v*'
   pull_request:
+  schedule:
+    # run every Monday at 5am UTC
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        sphinx: [">=5,<9"]  # Newest Sphinx (any)
-        myst-parser: [">=1,<3"]  # Newest MyST Parser (any)
+        sphinx: [""]  # Newest Sphinx (any)
+        myst-parser: [""]  # Newest MyST Parser (any)
         include:
           # Just check the other platforms once
           - os: windows-latest

--- a/.github/workflows/tests_devdeps.yml
+++ b/.github/workflows/tests_devdeps.yml
@@ -1,0 +1,36 @@
+name: continuous-integration-devdeps
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    # run every Monday at 5am UTC
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+
+  tests:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        sphinx: [""]  # Newest Sphinx (any)
+        myst-parser: [""]  # Newest MyST Parser (any)
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+        cache: pip
+    - name: Install myst-nb with development Sphinx and myst-parser versions
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade git+https://github.com/executablebooks/MyST-Parser.git#egg=myst-parser git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx -e .[testing]
+
+    - name: Run pytest
+      run: pytest --durations=10

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     ipython
 setenv =
     BUILDER = {env:BUILDER:html}
-whitelist_externals =
+allowlist_externals =
     echo
     rm
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ allowlist_externals =
     echo
     rm
 commands =
+    pip freeze
     clean: rm -rf docs/_build
     sphinx-build {posargs} -nW --keep-going -b {env:BUILDER} docs/ docs/_build/{env:BUILDER}
 commands_post = echo "open file://{toxinidir}/docs/_build/{env:BUILDER}/index.html"


### PR DESCRIPTION
Some cleanup and enhancement to the CI.

I choose to not run the devdeps job on PRs so e.g. new sphinx incompatibilities won't create failing CI status for them. However, test will run weekly on master, so incompatibilities can be picked up.


I included testing only with myst-parser and sphinx dev versions, but the job can be extended to include other dependencies. 

