### PR TITLE
add `configuration` key to readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,5 +14,6 @@ python:
       - requirements: docs/requirements.txt
 
 sphinx:
+  configuration: docs/conf.py
   builder: html
   fail_on_warning: true


### PR DESCRIPTION
When opening https://github.com/executablebooks/MyST-NB/pull/656, the [build failed](https://readthedocs.org/projects/myst-nb/builds/27027868/) because [an explicit configuration key is now required](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)

so anyway here's that