### PR TITLE
MAINT: minor cleanups

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 # this is only required by coconut kernel
-ipython
+# Version limit is due to coconut and ipython inncompatibility as of 24/4/2025
+ipython<9


### PR DESCRIPTION
I see some RTD issues over at https://github.com/executablebooks/MyST-NB/pull/646, so open this small PR to test out and if needed to fix it.

After this PR the auto generated released docs will be cleaner, (~and it also removes an unnecessary deprecation workaround~ it is still required to keep compatibility with sphinx 8.1.3.)