### PR TITLE
Fix link to EBP Contributing Guide

### DIFF
--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -6,7 +6,7 @@
 [![Code style: black][black-badge]][black-link]
 
 We welcome all contributions!
-See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details, and below for guidance specific to MyST-NB.
+See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contribute/) for general details, and below for guidance specific to MyST-NB.
 
 ## Installation
 


### PR DESCRIPTION
Hi, just a small fix 😊 

Link now points to https://executablebooks.org/en/latest/contribute/