### PR TITLE
Add scroll_outputs configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,8 @@ Tag             | Description
 `remove-input`  | Remove the code cell input/source from the rendered output.
 `remove-output` | Remove the code cell output from the rendered output.
 `remove-stderr` | Remove the code cell output stderr from the rendered output.
+`scroll-output` or `output_scroll` | Make the cell output scrollable if it is too long.
+`scroll-input` | Make the cell input scrollable if it is too long.
 
 Additionally, for code execution, these tags are provided (via `nbclient`):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ Tag             | Description
 `remove-input`  | Remove the code cell input/source from the rendered output.
 `remove-output` | Remove the code cell output from the rendered output.
 `remove-stderr` | Remove the code cell output stderr from the rendered output.
-`scroll-output` or `output_scroll` | Make the cell output scrollable if it is too long.
+`scroll-output` | Make the cell output scrollable if it is too long.
 `scroll-input` | Make the cell input scrollable if it is too long.
 
 Additionally, for code execution, these tags are provided (via `nbclient`):

--- a/myst_nb/core/config.py
+++ b/myst_nb/core/config.py
@@ -334,6 +334,20 @@ class NbParserConfig:
         },
     )
 
+    scroll_outputs: bool = dc.field(
+        default=False,
+        metadata={
+            "validator": instance_of(bool),
+            "help": "Make long cell outputs scrollable",
+            "sections": (
+                Section.global_lvl,
+                Section.file_lvl,
+                Section.cell_lvl,
+                Section.render,
+            ),
+        },
+    )
+
     code_prompt_show: str = dc.field(
         default="Show code cell {type}",
         metadata={

--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -137,6 +137,15 @@ class MditRenderMixin:
         classes = ["cell"]
         for tag in tags:
             classes.append(f"tag_{tag.replace(' ', '_')}")
+        
+        # set class for scrollable output
+        scroll_outputs = self.get_cell_level_config(
+            "scroll_outputs", token.meta["metadata"], line=cell_line
+        )
+        if scroll_outputs and not any( # don't override cell tags
+            tag in ["scroll-output", "output_scroll"] for tag in tags
+        ):
+            classes.append("tag_output_scroll")
 
         # TODO do we need this -/_ duplication of tag names, or can we deprecate one?
         hide_cell = "hide-cell" in tags

--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -137,12 +137,12 @@ class MditRenderMixin:
         classes = ["cell"]
         for tag in tags:
             classes.append(f"tag_{tag.replace(' ', '_')}")
-        
+
         # set class for scrollable output
         scroll_outputs = self.get_cell_level_config(
             "scroll_outputs", token.meta["metadata"], line=cell_line
         )
-        if scroll_outputs and not any( # don't override cell tags
+        if scroll_outputs and not any(  # don't override cell tags
             tag in ["scroll-output", "output_scroll"] for tag in tags
         ):
             classes.append("tag_output_scroll")

--- a/myst_nb/core/render.py
+++ b/myst_nb/core/render.py
@@ -138,14 +138,15 @@ class MditRenderMixin:
         for tag in tags:
             classes.append(f"tag_{tag.replace(' ', '_')}")
 
-        # set class for scrollable output
+        # handle config option for scrollable outputs
         scroll_outputs = self.get_cell_level_config(
             "scroll_outputs", token.meta["metadata"], line=cell_line
         )
         if scroll_outputs and not any(  # don't override cell tags
             tag in ["scroll-output", "output_scroll"] for tag in tags
         ):
-            classes.append("tag_output_scroll")
+            # add the class defined in mystnb.css for scroll_outputs config option
+            classes.append("config_scroll_outputs")
 
         # TODO do we need this -/_ duplication of tag names, or can we deprecate one?
         hide_cell = "hide-cell" in tags

--- a/myst_nb/static/mystnb.css
+++ b/myst_nb/static/mystnb.css
@@ -281,65 +281,44 @@ tbody span.pasted-inline img {
  *
  * It was before in https://github.com/executablebooks/sphinx-book-theme/blob/eb1b6baf098b27605e8f2b7b2979b17ebf1b9540/src/sphinx_book_theme/assets/styles/extensions/_myst-nb.scss
 */
-
-div.cell.tag_output_scroll div.cell_output, div.cell.tag_scroll-output div.cell_output {
-	 max-height: 24em;
-	 overflow-y: auto;
-	 max-width: 100%;
-	 overflow-x: auto;
-}
-
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar, div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar {
-	 width: var(--mystnb-scrollbar-width);
-	 height: var(--mystnb-scrollbar-height);
-}
-
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb, div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb {
-	 background: var(--mystnb-scrollbar-thumb-color);
-	 border-radius: var(--mystnb-scrollbar-thumb-border-radius);
-}
-
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb:hover, div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb:hover {
-	 background: var(--mystnb-scrollbar-thumb-hover-color);
-}
-
-@media print {
-	 div.cell.tag_output_scroll div.cell_output, div.cell.tag_scroll-output div.cell_output {
-		 max-height: unset;
-		 overflow-y: visible;
-		 max-width: unset;
-		 overflow-x: visible;
-	}
-}
-
+div.cell.tag_output_scroll div.cell_output,
+div.cell.tag_scroll-output div.cell_output,
 div.cell.tag_scroll-input div.cell_input {
-	 max-height: 24em;
-	 overflow-y: auto;
-	 max-width: 100%;
-	 overflow-x: auto;
+  max-height: 24em;
+  overflow-y: auto;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
+/* Custom scrollbars */
+div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar,
+div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar {
-	 width: var(--mystnb-scrollbar-width);
-	 height: var(--mystnb-scrollbar-height);
+  width: var(--mystnb-scrollbar-width);
+  height: var(--mystnb-scrollbar-height);
 }
-
+div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb,
+div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar-thumb {
-	 background: var(--mystnb-scrollbar-thumb-color);
-	 border-radius: var(--mystnb-scrollbar-thumb-border-radius);
+  background: var(--mystnb-scrollbar-thumb-color);
+  border-radius: var(--mystnb-scrollbar-thumb-border-radius);
 }
-
+div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb:hover,
+div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb:hover,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar-thumb:hover {
-	 background: var(--mystnb-scrollbar-thumb-hover-color);
+  background: var(--mystnb-scrollbar-thumb-hover-color);
 }
 
+/* In print mode, remove scroll and max-height */
 @media print {
-	 div.cell.tag_scroll-input div.cell_input {
-		 max-height: unset;
-		 overflow-y: visible;
-		 max-width: unset;
-		 overflow-x: visible;
-	}
+  div.cell.tag_output_scroll div.cell_output,
+  div.cell.tag_scroll-output div.cell_output,
+  div.cell.tag_scroll-input div.cell_input {
+    max-height: unset;
+    overflow-y: visible;
+    max-width: unset;
+    overflow-x: visible;
+  }
 }
 
 /* Font colors for translated ANSI escape sequences

--- a/myst_nb/static/mystnb.css
+++ b/myst_nb/static/mystnb.css
@@ -281,8 +281,12 @@ tbody span.pasted-inline img {
  *
  * It was before in https://github.com/executablebooks/sphinx-book-theme/blob/eb1b6baf098b27605e8f2b7b2979b17ebf1b9540/src/sphinx_book_theme/assets/styles/extensions/_myst-nb.scss
 */
-div.cell.tag_output_scroll div.cell_output,
-div.cell.tag_scroll-output div.cell_output,
+div.cell:is(
+    .tag_output_scroll,
+    .tag_scroll-output,
+    .config_scroll_outputs
+  )
+  div.cell_output,
 div.cell.tag_scroll-input div.cell_input {
   max-height: 24em;
   overflow-y: auto;
@@ -290,29 +294,51 @@ div.cell.tag_scroll-input div.cell_input {
   overflow-x: auto;
 }
 
+div.cell.config_scroll_outputs div.cell_output:has(img) {
+  max-height: unset;
+}
+
 /* Custom scrollbars */
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar,
-div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar,
+div.cell:is(
+    .tag_output_scroll,
+    .tag_scroll-output,
+    .config_scroll_outputs
+  )
+  div.cell_output::-webkit-scrollbar,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar {
   width: var(--mystnb-scrollbar-width);
   height: var(--mystnb-scrollbar-height);
 }
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb,
-div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb,
+
+div.cell:is(
+    .tag_output_scroll,
+    .tag_scroll-output,
+    .config_scroll_outputs
+  )
+  div.cell_output::-webkit-scrollbar-thumb,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar-thumb {
   background: var(--mystnb-scrollbar-thumb-color);
   border-radius: var(--mystnb-scrollbar-thumb-border-radius);
 }
-div.cell.tag_output_scroll div.cell_output::-webkit-scrollbar-thumb:hover,
-div.cell.tag_scroll-output div.cell_output::-webkit-scrollbar-thumb:hover,
+
+div.cell:is(
+    .tag_output_scroll,
+    .tag_scroll-output,
+    .config_scroll_outputs
+  )
+  div.cell_output::-webkit-scrollbar-thumb:hover,
 div.cell.tag_scroll-input div.cell_input::-webkit-scrollbar-thumb:hover {
   background: var(--mystnb-scrollbar-thumb-hover-color);
 }
 
-/* In print mode, remove scroll and max-height */
+/* In print mode, unset scroll styles */
 @media print {
-  div.cell.tag_output_scroll div.cell_output,
-  div.cell.tag_scroll-output div.cell_output,
+  div.cell:is(
+      .tag_output_scroll,
+      .tag_scroll-output,
+      .config_scroll_outputs
+    )
+    div.cell_output,
   div.cell.tag_scroll-input div.cell_input {
     max-height: unset;
     overflow-y: visible;

--- a/myst_nb/static/mystnb.css
+++ b/myst_nb/static/mystnb.css
@@ -295,7 +295,9 @@ div.cell.tag_scroll-input div.cell_input {
 }
 
 div.cell.config_scroll_outputs div.cell_output:has(img) {
-  max-height: unset;
+  /* If the output cell has image(s), allow it to take 90% of viewport height
+  but still bounded between 24em and 60em */
+  max-height: clamp(24em, 90vh, 60em);
 }
 
 /* Custom scrollbars */

--- a/tests/notebooks/scroll_outputs.ipynb
+++ b/tests/notebooks/scroll_outputs.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "356e9205",
+   "metadata": {},
+   "source": [
+    "# Scroll long outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cd1b32ee",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "short output\n",
+      "short output\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(2):\n",
+    "    print(\"short output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "91a31d3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n",
+      "long output\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(100):\n",
+    "    print(\"long output\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "myst-nb-py311",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_render_outputs.py
+++ b/tests/test_render_outputs.py
@@ -195,8 +195,9 @@ def test_hide_cell_content(sphinx_run, file_regression):
     doctree = sphinx_run.get_resolved_doctree("hide_cell_content")
     file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
 
-@pytest.mark.sphinx_params("scroll_outputs.ipynb", 
-    conf={"nb_execution_mode": "off", "nb_scroll_outputs": True}
+
+@pytest.mark.sphinx_params(
+    "scroll_outputs.ipynb", conf={"nb_execution_mode": "off", "nb_scroll_outputs": True}
 )
 def test_scroll_outputs(sphinx_run, file_regression):
     """Test that scrollable outputs are rendered correctly."""

--- a/tests/test_render_outputs.py
+++ b/tests/test_render_outputs.py
@@ -194,3 +194,13 @@ def test_hide_cell_content(sphinx_run, file_regression):
     assert sphinx_run.warnings() == ""
     doctree = sphinx_run.get_resolved_doctree("hide_cell_content")
     file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")
+
+@pytest.mark.sphinx_params("scroll_outputs.ipynb", 
+    conf={"nb_execution_mode": "off", "nb_scroll_outputs": True}
+)
+def test_scroll_outputs(sphinx_run, file_regression):
+    """Test that scrollable outputs are rendered correctly."""
+    sphinx_run.build()
+    assert sphinx_run.warnings() == ""
+    doctree = sphinx_run.get_resolved_doctree("scroll_outputs")
+    file_regression.check(doctree.pformat(), extension=".xml", encoding="utf-8")

--- a/tests/test_render_outputs/test_scroll_outputs.xml
+++ b/tests/test_render_outputs/test_scroll_outputs.xml
@@ -1,0 +1,120 @@
+<document source="scroll_outputs">
+    <section ids="scroll-long-outputs" names="scroll\ long\ outputs">
+        <title>
+            Scroll long outputs
+        <container cell_index="1" cell_metadata="{}" classes="cell tag_output_scroll" exec_count="2" nb_element="cell_code">
+            <container classes="cell_input" nb_element="cell_code_source">
+                <literal_block language="ipython3" linenos="False" xml:space="preserve">
+                    for i in range(2):
+                        print("short output")
+            <container classes="cell_output" nb_element="cell_code_output">
+                <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
+                    short output
+                    short output
+        <container cell_index="2" cell_metadata="{}" classes="cell tag_output_scroll" exec_count="1" nb_element="cell_code">
+            <container classes="cell_input" nb_element="cell_code_source">
+                <literal_block language="ipython3" linenos="False" xml:space="preserve">
+                    for i in range(100):
+                        print("long output")
+            <container classes="cell_output" nb_element="cell_code_output">
+                <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output
+                    long output

--- a/tests/test_render_outputs/test_scroll_outputs.xml
+++ b/tests/test_render_outputs/test_scroll_outputs.xml
@@ -2,7 +2,7 @@
     <section ids="scroll-long-outputs" names="scroll\ long\ outputs">
         <title>
             Scroll long outputs
-        <container cell_index="1" cell_metadata="{}" classes="cell tag_output_scroll" exec_count="2" nb_element="cell_code">
+        <container cell_index="1" cell_metadata="{}" classes="cell config_scroll_outputs" exec_count="2" nb_element="cell_code">
             <container classes="cell_input" nb_element="cell_code_source">
                 <literal_block language="ipython3" linenos="False" xml:space="preserve">
                     for i in range(2):
@@ -11,7 +11,7 @@
                 <literal_block classes="output stream" language="myst-ansi" linenos="False" xml:space="preserve">
                     short output
                     short output
-        <container cell_index="2" cell_metadata="{}" classes="cell tag_output_scroll" exec_count="1" nb_element="cell_code">
+        <container cell_index="2" cell_metadata="{}" classes="cell config_scroll_outputs" exec_count="1" nb_element="cell_code">
             <container classes="cell_input" nb_element="cell_code_source">
                 <literal_block language="ipython3" linenos="False" xml:space="preserve">
                     for i in range(100):


### PR DESCRIPTION
Fixes #677 

* Introduced a new configuration option `scroll_outputs` in `myst_nb/core/config.py` to enable scrollable long outputs - configurable at global, file, cell, and render levels.
* Updated the `myst_nb/core/render.py` logic to apply the `tag_output_scroll` class to cells when the `scroll_outputs` configuration is enabled.
* Added tests for this config: test case in `test_render_outputs.py`, input notebook `scroll_outputs.ipynb` and output AST `test_scroll_outputs.xml`. This was heavily inspired from [hide_cell_content option PR](https://github.com/executablebooks/MyST-NB/pull/446/files#diff-362105cf18876b3c511844baa054405a6ea93b1a36d1666159d8e36866247b3c).

* [Bonus] Added tags `scroll-output` (or `output_scroll`) and `scroll-input` in documentation (they was no documentation [when they were added](https://github.com/executablebooks/MyST-NB/commit/4b7a0eda8574416aca3e213e8cdaf310427beaf9))
