### PR TITLE
Fix dead link in error directive message

### DIFF
--- a/myst_nb/core/read.py
+++ b/myst_nb/core/read.py
@@ -399,7 +399,7 @@ class UnexpectedCellDirective(Directive):
             "Either this file was not converted to a notebook, "
             "because Jupytext header content was missing, "
             "or the `code-cell` was not converted, because it is nested. "
-            "See https://myst-nb.readthedocs.io/en/latest/use/markdown.html "
+            "See https://myst-nb.readthedocs.io/en/latest/authoring/text-notebooks.html "
             "for more information."
         )
         document = self.state.document


### PR DESCRIPTION
The link shown when an Unexpected Cell Directive is encountered is not valid (404) anymore.