### PR TITLE
feat: allow passing kernel manager to parser

### DIFF
--- a/myst_nb/core/execute/__init__.py
+++ b/myst_nb/core/execute/__init__.py
@@ -10,6 +10,7 @@ from .inline import NotebookClientInline
 
 if TYPE_CHECKING:
     from nbformat import NotebookNode
+    from jupyter_client.manager import KernelManager
 
     from myst_nb.core.config import NbParserConfig
     from myst_nb.core.loggers import LoggerType
@@ -21,6 +22,8 @@ def create_client(
     nb_config: NbParserConfig,
     logger: LoggerType,
     read_fmt: None | dict = None,
+    *,
+    km: KernelManager | None = None,
 ) -> NotebookClientBase:
     """Create a notebook execution client, to update its outputs.
 
@@ -59,12 +62,14 @@ def create_client(
         return NotebookClientBase(notebook, path, nb_config, logger)
 
     if nb_config.execution_mode in ("auto", "force"):
-        return NotebookClientDirect(notebook, path, nb_config, logger)
+        return NotebookClientDirect(notebook, path, nb_config, logger, km=km)
 
     if nb_config.execution_mode == "cache":
-        return NotebookClientCache(notebook, path, nb_config, logger, read_fmt=read_fmt)
+        return NotebookClientCache(
+            notebook, path, nb_config, logger, read_fmt=read_fmt, km=km
+        )
 
     if nb_config.execution_mode == "inline":
-        return NotebookClientInline(notebook, path, nb_config, logger)
+        return NotebookClientInline(notebook, path, nb_config, logger, km=km)
 
     return NotebookClientBase(notebook, path, nb_config, logger)

--- a/myst_nb/core/execute/__init__.py
+++ b/myst_nb/core/execute/__init__.py
@@ -23,7 +23,7 @@ def create_client(
     logger: LoggerType,
     read_fmt: None | dict = None,
     *,
-    km: KernelManager | None = None,
+    kernel_manager: KernelManager | None = None,
 ) -> NotebookClientBase:
     """Create a notebook execution client, to update its outputs.
 
@@ -62,14 +62,20 @@ def create_client(
         return NotebookClientBase(notebook, path, nb_config, logger)
 
     if nb_config.execution_mode in ("auto", "force"):
-        return NotebookClientDirect(notebook, path, nb_config, logger, km=km)
+        return NotebookClientDirect(
+            notebook, path, nb_config, logger, kernel_manager=kernel_manager
+        )
 
     if nb_config.execution_mode == "cache":
         return NotebookClientCache(
-            notebook, path, nb_config, logger, read_fmt=read_fmt, km=km
+            *(notebook, path, nb_config, logger),
+            read_fmt=read_fmt,
+            kernel_manager=kernel_manager,
         )
 
     if nb_config.execution_mode == "inline":
-        return NotebookClientInline(notebook, path, nb_config, logger, km=km)
+        return NotebookClientInline(
+            notebook, path, nb_config, logger, kernel_manager=kernel_manager
+        )
 
     return NotebookClientBase(notebook, path, nb_config, logger)

--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -58,7 +58,7 @@ class NotebookClientBase:
         nb_config: NbParserConfig,
         logger: LoggerType,
         *,
-        km: KernelManager | None = None,
+        kernel_manager: KernelManager | None = None,
         **kwargs: Any,
     ):
         """Initialize the client."""
@@ -66,7 +66,7 @@ class NotebookClientBase:
         self._path = path
         self._nb_config = nb_config
         self._logger = logger
-        self._km = km
+        self._kernel_manager = kernel_manager
         self._kwargs = kwargs
 
         self._glue_data: dict[str, NotebookNode] = {}

--- a/myst_nb/core/execute/base.py
+++ b/myst_nb/core/execute/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from nbformat import NotebookNode
 from typing_extensions import TypedDict, final
@@ -12,6 +12,9 @@ from myst_nb.core.config import NbParserConfig
 from myst_nb.core.loggers import LoggerType
 from myst_nb.core.nb_to_tokens import nb_node_to_dict
 from myst_nb.ext.glue import extract_glue_data
+
+if TYPE_CHECKING:
+    from jupyter_client import KernelManager
 
 
 class ExecutionResult(TypedDict):
@@ -54,6 +57,8 @@ class NotebookClientBase:
         path: Path | None,
         nb_config: NbParserConfig,
         logger: LoggerType,
+        *,
+        km: KernelManager | None = None,
         **kwargs: Any,
     ):
         """Initialize the client."""
@@ -61,6 +66,7 @@ class NotebookClientBase:
         self._path = path
         self._nb_config = nb_config
         self._logger = logger
+        self._km = km
         self._kwargs = kwargs
 
         self._glue_data: dict[str, NotebookNode] = {}

--- a/myst_nb/core/execute/cache.py
+++ b/myst_nb/core/execute/cache.py
@@ -76,6 +76,7 @@ class NotebookClientCache(NotebookClientBase):
                 allow_errors=self.nb_config.execution_allow_errors,
                 timeout=self.nb_config.execution_timeout,
                 meta_override=True,  # TODO still support this?
+                km=self._km,
             )
 
         # handle success / failure cases

--- a/myst_nb/core/execute/cache.py
+++ b/myst_nb/core/execute/cache.py
@@ -76,7 +76,7 @@ class NotebookClientCache(NotebookClientBase):
                 allow_errors=self.nb_config.execution_allow_errors,
                 timeout=self.nb_config.execution_timeout,
                 meta_override=True,  # TODO still support this?
-                km=self._km,
+                km=self._kernel_manager,
             )
 
         # handle success / failure cases

--- a/myst_nb/core/execute/direct.py
+++ b/myst_nb/core/execute/direct.py
@@ -44,6 +44,7 @@ class NotebookClientDirect(NotebookClientBase):
                 allow_errors=self.nb_config.execution_allow_errors,
                 timeout=self.nb_config.execution_timeout,
                 meta_override=True,  # TODO still support this?
+                km=self._km,
             )
 
         if result.err is not None:

--- a/myst_nb/core/execute/direct.py
+++ b/myst_nb/core/execute/direct.py
@@ -44,7 +44,7 @@ class NotebookClientDirect(NotebookClientBase):
                 allow_errors=self.nb_config.execution_allow_errors,
                 timeout=self.nb_config.execution_timeout,
                 meta_override=True,  # TODO still support this?
-                km=self._km,
+                km=self._kernel_manager,
             )
 
         if result.err is not None:

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -56,6 +56,7 @@ class NotebookClientInline(NotebookClientBase):
             resources=resources,
             allow_errors=self.nb_config.execution_allow_errors,
             timeout=self.nb_config.execution_timeout,
+            km=self._km,
         )
         self._client.reset_execution_trackers()
         if self._client.km is None:

--- a/myst_nb/core/execute/inline.py
+++ b/myst_nb/core/execute/inline.py
@@ -56,7 +56,7 @@ class NotebookClientInline(NotebookClientBase):
             resources=resources,
             allow_errors=self.nb_config.execution_allow_errors,
             timeout=self.nb_config.execution_timeout,
-            km=self._km,
+            km=self._kernel_manager,
         )
         self._client.reset_execution_trackers()
         if self._client.km is None:

--- a/myst_nb/docutils_.py
+++ b/myst_nb/docutils_.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache, partial
 from importlib import resources as import_resources
 import os
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from docutils import nodes
 from docutils.core import default_description, publish_cmdline
@@ -46,6 +46,10 @@ from myst_nb.ext.eval import load_eval_docutils
 from myst_nb.ext.glue import load_glue_docutils
 from myst_nb.warnings_ import MystNBWarnings, create_warning
 
+if TYPE_CHECKING:
+    from jupyter_client import KernelManager
+
+
 DOCUTILS_EXCLUDED_ARGS = list(
     {f.name for f in NbParserConfig.get_fields() if f.metadata.get("docutils_exclude")}
 )
@@ -82,6 +86,10 @@ class Parser(MystParser):
     """Runtime settings specification."""
 
     config_section = "myst-nb parser"
+
+    def __init__(self, *args, km: KernelManager | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.km = km
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         # register/unregister special directives and roles
@@ -187,7 +195,9 @@ class Parser(MystParser):
 
         # open the notebook execution client,
         # this may execute the notebook immediately or during the page render
-        with create_client(notebook, document_source, nb_config, logger) as nb_client:
+        with create_client(
+            notebook, document_source, nb_config, logger, km=self.km
+        ) as nb_client:
             mdit_parser.options["nb_client"] = nb_client
             # convert to docutils AST, which is added to the document
             mdit_renderer.render(mdit_tokens, mdit_parser.options, mdit_env)

--- a/myst_nb/docutils_.py
+++ b/myst_nb/docutils_.py
@@ -87,9 +87,9 @@ class Parser(MystParser):
 
     config_section = "myst-nb parser"
 
-    def __init__(self, *args, km: KernelManager | None = None, **kwargs):
+    def __init__(self, *args, kernel_manager: KernelManager | None = None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.km = km
+        self.kernel_manager = kernel_manager
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         # register/unregister special directives and roles
@@ -196,7 +196,8 @@ class Parser(MystParser):
         # open the notebook execution client,
         # this may execute the notebook immediately or during the page render
         with create_client(
-            notebook, document_source, nb_config, logger, km=self.km
+            *(notebook, document_source, nb_config, logger),
+            kernel_manager=self.kernel_manager,
         ) as nb_client:
             mdit_parser.options["nb_client"] = nb_client
             # convert to docutils AST, which is added to the document

--- a/myst_nb/sphinx_.py
+++ b/myst_nb/sphinx_.py
@@ -7,7 +7,7 @@ from html import escape
 import json
 from pathlib import Path
 import re
-from typing import Any, DefaultDict, cast
+from typing import Any, DefaultDict, cast, TYPE_CHECKING
 
 from docutils import nodes
 from markdown_it.token import Token
@@ -41,6 +41,10 @@ from myst_nb.core.render import (
 )
 from myst_nb.warnings_ import MystNBWarnings, create_warning
 
+if TYPE_CHECKING:
+    from jupyter_client import KernelManager
+
+
 SPHINX_LOGGER = sphinx_logging.getLogger(__name__)
 
 
@@ -63,6 +67,10 @@ class Parser(MystParser):
     config_section_dependencies = ("parsers",)
 
     env: SphinxEnvType
+
+    def __init__(self, *args, km: KernelManager | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.km = km
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         """Parse source text.
@@ -154,7 +162,7 @@ class Parser(MystParser):
         # open the notebook execution client,
         # this may execute the notebook immediately or during the page render
         with create_client(
-            notebook, document_path, nb_config, logger, nb_reader.read_fmt
+            notebook, document_path, nb_config, logger, nb_reader.read_fmt, km=self.km
         ) as nb_client:
             mdit_parser.options["nb_client"] = nb_client
             # convert to docutils AST, which is added to the document

--- a/myst_nb/sphinx_.py
+++ b/myst_nb/sphinx_.py
@@ -68,9 +68,9 @@ class Parser(MystParser):
 
     env: SphinxEnvType
 
-    def __init__(self, *args, km: KernelManager | None = None, **kwargs):
+    def __init__(self, *args, kernel_manager: KernelManager | None = None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.km = km
+        self.kernel_manager = kernel_manager
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         """Parse source text.
@@ -162,7 +162,8 @@ class Parser(MystParser):
         # open the notebook execution client,
         # this may execute the notebook immediately or during the page render
         with create_client(
-            notebook, document_path, nb_config, logger, nb_reader.read_fmt, km=self.km
+            *(notebook, document_path, nb_config, logger, nb_reader.read_fmt),
+            kernel_manager=self.kernel_manager,
         ) as nb_client:
             mdit_parser.options["nb_client"] = nb_client
             # convert to docutils AST, which is added to the document


### PR DESCRIPTION
Hi, I built [sphinx-exec-jupyter](https://github.com/flying-sheep/sphinx-exec-jupyter#readme) to leverage myst-nb’s machinery for running code blocks in isolation.

In it, I’m using a custom `KernelClient` for efficiency.

This client needs to be passed down all the way to `executenb`, and it would be great if that was possible without monkeypatching `myst-nb`.

## Usage

It can be used directly when using a `Parser` programmaticly:


```py
from myst_nb.sphinx_ import Parser

parser = Parser(km=MyKernelManager())
parser.parse(...)
```

… or by overriding the registered parser in a Sphinx extension like this:

```py
from docutils import nodes
from myst_nb.sphinx_ import Parser

class SomeKernelManager(...): ...

class MyParser(Parser):
    # could override in `__init__` or here
    def parse(self, inputstring: str, document: nodes.document) -> None:
        self.km = MyKernelManager(document.settings.env)
        return super().parse(inputstring, document)

def setup(app):
    app.setup_extension("myst_nb")
    app.add_source_parser(MyParser, override=True)
```

## Possible alternatives

- Instead of adding the `km` property to the parser and passing them to `create_client`, we could wrap `create_client` into a method on `Parser`, then I could override it. The other changes would still be necessary.

- In addition to the above method, I could break up `parse` into more granular steps in general for easier extensibility.