### PR TITLE
fix: render nested code-cell source instead of dropping it

### DIFF
--- a/myst_nb/core/read.py
+++ b/myst_nb/core/read.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from typing import Callable, Iterator
 
+from docutils import nodes
 from docutils.parsers.rst import Directive
 from markdown_it.renderer import RendererHTML
 from myst_parser.config.main import MdParserConfig
@@ -382,10 +383,9 @@ class UnexpectedCellDirective(Directive):
     which are picked up by the MyST Markdown reader to convert them into notebooks.
 
     If any are left in the parsed Markdown, it probably means that they were nested
-    inside another directive, which is not allowed.
+    inside another directive, so they cannot be converted into notebook cells.
 
-    Therefore, we log a warning if it is triggered, and discard it.
-
+    Therefore, we log a warning and fall back to rendering the source as a code block.
     """
 
     optional_arguments = 1
@@ -408,4 +408,8 @@ class UnexpectedCellDirective(Directive):
         else:
             logger = DocutilsDocLogger(document)  # type: ignore
         logger.warning(message, line=self.lineno, subtype="nbcell")
-        return []
+        source = "\n".join(self.content)
+        node = nodes.literal_block(source, source)
+        if self.arguments:
+            node["language"] = self.arguments[0]
+        return [node]

--- a/tests/notebooks/nested_code_cell.md
+++ b/tests/notebooks/nested_code_cell.md
@@ -1,0 +1,23 @@
+---
+file_format: mystnb
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Nested code cells
+
+## Control: standalone code cell (should render)
+
+```{code-cell} python
+print("hello from standalone cell")
+```
+
+## Reproducer: code cell nested in another directive (should still render source)
+
+````{note}
+```{code-cell} python
+print("hello from nested cell")
+```
+````

--- a/tests/test_text_based.py
+++ b/tests/test_text_based.py
@@ -68,3 +68,17 @@ def test_basic_nometadata(sphinx_run):
     sphinx_run.build()
     # print(sphinx_run.status())
     assert "Found an unexpected `code-cell`" in sphinx_run.warnings()
+
+
+@pytest.mark.sphinx_params(
+    "nested_code_cell.md",
+    conf={"nb_execution_mode": "off", "source_suffix": {".md": "myst-nb"}},
+)
+def test_nested_code_cell_renders_source(sphinx_run):
+    """Nested code-cell directives cannot become notebook cells, but source must show."""
+    sphinx_run.build()
+    assert "Found an unexpected `code-cell`" in sphinx_run.warnings()
+    html = sphinx_run.get_html()
+    sources = [block.get_text() for block in html.find_all("div", class_="highlight")]
+    assert any("hello from standalone cell" in s for s in sources)
+    assert any("hello from nested cell" in s for s in sources)


### PR DESCRIPTION
## Summary

Nested `{code-cell}` directives (for example inside `{tab-set}` / `{tab-item}` or other containers) are not converted into notebook cells by the Markdown reader. `UnexpectedCellDirective` previously returned an empty node list, so the source disappeared from the built HTML while only a warning remained.

Keep the existing warning, and fall back to rendering the cell source as a `literal_block` (with the language from the directive argument when present). Nested cells are still not executed.

## Test plan

- [x] `pytest tests/test_text_based.py` — new `test_nested_code_cell_renders_source` asserts nested source appears in HTML and the unexpected-cell warning still fires
- [x] Related suite (`tests/test_text_based.py`, `tests/test_codecell_file.py`, `tests/test_docutils.py`) and full suite green locally

Fixes #723